### PR TITLE
Batt_dispatch_choice update to switch choice to Automated for FOM

### DIFF
--- a/deploy/runtime/ui/Battery Dispatch Automated FOM.txt
+++ b/deploy/runtime/ui/Battery Dispatch Automated FOM.txt
@@ -684,12 +684,13 @@ Battery Dispatch
 TextEntry
 
 0
-3805
+3840
 on_load{'Battery Dispatch Automated FOM'}=define()
 {	
 	// fom = front of meter
 	
 	on_change{'batt_dispatch_wf_forecast_choice'};
+	value('batt_dispatch_choice', 0);
 	toggle_dispatch_fom_automated();
 	if (technology() == "Fuel Cell")
 		toggle_dispatch();


### PR DESCRIPTION
-Switching batt_dispatch_choice_ui radio buttons from another option to Automated does not update batt_dispatch_choice as it should. 
-Battery model is still running prior selection for the dispatch option
-This fix should fix that behavior