### PR TITLE
Increase pvwatts-battery o&m to account for battery o&m

### DIFF
--- a/deploy/runtime/defaults/PVWatts Battery_Commercial.json
+++ b/deploy/runtime/defaults/PVWatts Battery_Commercial.json
@@ -35479,7 +35479,7 @@
     "nominal_discount_rate": 9.06,
     "normalize_to_utility_bill": 0.0,
     "om_capacity": [
-        18.0
+        58.0
     ],
     "om_capacity_escal": 0.0,
     "om_fixed": [

--- a/deploy/runtime/defaults/PVWatts Battery_Host Developer.json
+++ b/deploy/runtime/defaults/PVWatts Battery_Host Developer.json
@@ -45631,7 +45631,7 @@
     "nominal_discount_rate": 9.06,
     "normalize_to_utility_bill": 0.0,
     "om_capacity": [
-        18.0
+        58.0
     ],
     "om_capacity_escal": 0.0,
     "om_fixed": [

--- a/deploy/runtime/defaults/PVWatts Battery_Residential.json
+++ b/deploy/runtime/defaults/PVWatts Battery_Residential.json
@@ -35523,7 +35523,7 @@
     "nominal_discount_rate": 9.06,
     "normalize_to_utility_bill": 0.0,
     "om_capacity": [
-        31.0
+        56.0
     ],
     "om_capacity_escal": 0.0,
     "om_fixed": [

--- a/test_results_win64.csv
+++ b/test_results_win64.csv
@@ -38,10 +38,10 @@ PV Battery,Merchant Plant,217336480,8.57725,NA,; Warning: IRR at end of analysis
 PV Battery,Leveraged Partnership Flip,217336480,6.58541,8.8994,; Warning: IRR at end of analysis period is not a number (NaN). This can indicate that revenues are too low to cover costs, or that they are excessively high compared to costs.
 PV Battery,All Equity Partnership Flip,217336480,9.24934,8.8994,; Warning: IRR at end of analysis period is not a number (NaN). This can indicate that revenues are too low to cover costs, or that they are excessively high compared to costs. Warning: IRR in target year is not a number (NaN). This can indicate that revenues are too low to cover costs, or that they are excessively high compared to costs. Warning: NPV is $-1.08217e+07. A negative NPV indicates project costs are higher than revenues.
 PV Battery,Sale Leaseback,217336480,9.94943,8.8994,; Warning: IRR at end of analysis period is not a number (NaN). This can indicate that revenues are too low to cover costs, or that they are excessively high compared to costs. Warning: NPV is $-2.17579e+07. A negative NPV indicates project costs are higher than revenues.
-PVWatts Battery,Residential,13669.6,13.5922,NA,; 
-PVWatts Battery,Commercial,929998,10.9083,NA,; 
+PVWatts Battery,Residential,13669.6,15.4129,NA,; 
+PVWatts Battery,Commercial,929998,13.063,NA,; 
 PVWatts Battery,Third Party,11003.4,NA,NA,; 
-PVWatts Battery,Host Developer,929998,17.806,16.2118,; Warning: NPV is $-141024. A negative NPV indicates project costs are higher than revenues.
+PVWatts Battery,Host Developer,929998,20.5643,16.2118,; Warning: NPV is $-385041. A negative NPV indicates project costs are higher than revenues.
 Generic Battery,Residential,6694.13,65.3428,NA,; 
 Generic Battery,Commercial,359924,41.4888,NA,; 
 Generic Battery,Third Party,6690.41,NA,NA,; 
@@ -60,7 +60,7 @@ Standalone Battery,Merchant Plant,-8397703,25.7208,NA,; Warning: IRR at end of a
 Standalone Battery,Leveraged Partnership Flip,-8397703,81.3387,88.6283,; Warning: IRR at end of analysis period is not a number (NaN). This can indicate that revenues are too low to cover costs, or that they are excessively high compared to costs.
 Standalone Battery,All Equity Partnership Flip,-8397703,85.2731,88.6283,; Warning: IRR at end of analysis period is not a number (NaN). This can indicate that revenues are too low to cover costs, or that they are excessively high compared to costs.
 Standalone Battery,Sale Leaseback,-8397703,86.2847,88.6283,; Warning: IRR at end of analysis period is not a number (NaN). This can indicate that revenues are too low to cover costs, or that they are excessively high compared to costs. Warning: NPV is $-1.09395e+08. A negative NPV indicates project costs are higher than revenues.
-ETES,Single Owner,-467888608,13.345,7.39838,; 
+ETES,Single Owner,-466777408,13.3154,7.40086,; 
 PTES,Single Owner,-197577712,16.8928,10.3679,; 
 Physical Trough,Single Owner,376683104,12.2069,12.3469,; 
 Physical Trough,Merchant Plant,376683104,12.8783,NA,; 


### PR DESCRIPTION
# Pull Request Template

## Description

Add battery O&M from detailed cases to PVWatts-Battery single-line O&M number. Since detailed number is `$/kWh`, multiply by number of hours of storage to convert to `$/kW`.

Fixes https://github.com/NREL/SAM/issues/1298

## Type of change

Please delete options that are not relevant.

- [X] Bug fix (non-breaking change which fixes an issue)


## Checklist:

If you have added a new compute module in a SSC pull request related to this one, be sure to check the [Process Requirements](https://github.com/NREL/SAM/wiki/Compute-modules-in-SAM).

- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [X] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [X] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
- [X] I have checked my code and corrected any misspellings
