### PR TITLE
remove snappy package due to GPL 2.0 license, EULP script runs fine

### DIFF
--- a/samples/Python Scripts/End Use Load Profiles/eulp/requirements.txt
+++ b/samples/Python Scripts/End Use Load Profiles/eulp/requirements.txt
@@ -3,5 +3,4 @@ matplotlib==3.6.0
 pandas==1.5.2
 pyarrow==14.0.1
 seaborn==0.12.1
-snappy==3.1.1
 urllib3==1.26.18


### PR DESCRIPTION
Remove for FOSSA compliance. It looks like pip dependencies have improved and that package is not actually needed.