### PR TITLE
Combine cases macro checks lifetime mode

### DIFF
--- a/src/combinecases.cpp
+++ b/src/combinecases.cpp
@@ -262,7 +262,9 @@ void CombineCasesDialog::OnEvt(wxCommandEvent& e)
 							analysis_period_this = current_case->Values(0).Get("c_lifetime")->Value();
 						}
 						else if (financial_name != "None") {
+							bool use_lifetime = current_case->Values(0).Get("system_use_lifetime_output")->Boolean();
 							analysis_period_this = current_case->Values(0).Get("analysis_period")->Value();
+							analysis_period_this = use_lifetime ? analysis_period_this : 1;
 						}
 
 						// determine hourly generation profile of current case

--- a/src/combinecases.cpp
+++ b/src/combinecases.cpp
@@ -282,7 +282,7 @@ void CombineCasesDialog::OnEvt(wxCommandEvent& e)
 							SamApp::Window()->SwitchToCaseWindow(m_custom_generation_case_name);
 							m_custom_generation_case_window->SwitchToInputPage("Power Plant");
 							wxMessageBox("Subhourly simulations unsupported\n\n"
-								"The subhourly simulation for case " + technology_name + " is not supported.",
+								"The subhourly simulation for case " + case_name + " is not supported.",
 								"Combine Cases Message", wxOK, this);
 							return;
 						}


### PR DESCRIPTION
# Pull Request Template

## Description

Add code to check whether or not a simulation uses lifetime mode prior to assessing whether or not the simulation is subhourly

Fixes #1752

To test: Create a PVWatts case with a subhourly weather file, a PVWatts case with an hourly weather file, and a custom generation case that combines these two cases. The combine cases script should flag the fact that a case is subhourly and give an error that it is not currently supported.

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
