### PR TITLE
Update collectors to PTC library

### DIFF
--- a/deploy/libraries/Physical Trough Collectors.csv
+++ b/deploy/libraries/Physical Trough Collectors.csv
@@ -1,7 +1,6 @@
 Name,Description,Reflective aperture area,Aperture width  total structure,Length of collector assembly,Number of modules per assembly,Average surface to focus path length,Piping distance between assemblies,IAM F0,IAM F1,IAM F2,IAM F3,Tracking error,Geometry effects,Mirror reflectance,Dirt on mirror,General optical error
 Units,-,m2,m,m,-,m,m,-,-,-,-,-,-,-,-,-
 [0],lib_collector_description,lib_A_aperture,lib_W_aperture,lib_L_SCA,lib_ColperSCA,lib_Ave_Focal_Length,lib_Distance_SCA,lib_IamF0,lib_IamF1,lib_IamF2,lib_IamF3,lib_TrackingError,lib_GeomEffects,lib_Rho_mirror_clean,lib_Dirt_mirror,lib_Error
-EuroTrough ET150,EuroTrough ET150,817.5,5.75,150,12,2.11,1,1,0.0506,-0.1763,0,0.99,0.98,0.935,0.97,0.99
 Luz LS-2,Luz LS-2,235,5,49,6,1.8,1,1,0.0506,-0.1763,0,0.99,0.98,0.935,0.97,0.99
 Luz LS-3,Luz LS-3,545,5.75,100,12,2.11,1,1,0.0506,-0.1763,0,0.99,0.98,0.935,0.97,0.99
 Solargenix SGX-1,Solargenix SGX-1,470.3,5,100,12,1.8,1,1,0.0506,-0.1763,0,0.994,0.98,0.935,0.97,0.99
@@ -13,4 +12,4 @@ FLABEG Ultimate Trough RP6 (with 70-mm OD receiver for molten-salt HTF),FLABEG U
 SunBeam IPH, Solar Dynamics SunBeam MT,1320,8.2,168,8,2.89,1,1,-0.008,-0.117,0,0.99,0.98,0.935,0.97,0.99
 SENERtrough-1,ST-1,817.5,5.75,150,12,2.11,1,1,-0.000278005,-0.000042806,0,0.99,0.98,0.935,0.97,0.995
 SENERtrough-2,ST-2,1047,6.87,160,12,2.49,1.1,1,-0.000278005,-0.000042806,0,0.99,0.98,0.935,0.97,0.995
-EuroTrough ET150 - to use,EuroTrough ET150,817.5,5.75,150,12,2.11,1,1,-0.000278005,-0.000042806,0,0.99,0.98,0.935,0.97,0.99
+EuroTrough ET150,EuroTrough ET150,817.5,5.75,150,12,2.11,1,1,-0.000278005,-0.000042806,0,0.99,0.98,0.935,0.97,0.99

--- a/deploy/libraries/Physical Trough Collectors.csv
+++ b/deploy/libraries/Physical Trough Collectors.csv
@@ -10,4 +10,7 @@ Siemens SunField 6,Siemens SunField 6,545,5.776,95.2,8,2.17,0.8,1,-0.0753,-0.036
 SkyFuel SkyTrough (with 80-mm OD receiver),SkyFuel SkyTrough (with 80-mm OD receiver),656,6,115,8,2.15,1,1,0.0327,-0.1351,0,0.988,0.952,0.93,0.97,1
 FLABEG Ultimate Trough RP6 (with 89-mm OD receiver for oil HTF),FLABEG Ultimate Trough RP6 (with 89-mm OD receiver for oil HTF),1720,7.53,247,10,2.38,1.5,1,-0.005,-0.102,0,0.998,0.99,0.94,0.97,1
 FLABEG Ultimate Trough RP6 (with 70-mm OD receiver for molten-salt HTF),FLABEG Ultimate Trough RP6 (with 70-mm OD receiver for molten-salt HTF),1720,7.53,247,10,2.38,1.5,1,-0.008,-0.117,0,0.998,0.97,0.94,0.97,1
-SunBeam IPH, Solar Dynamics SunBeam MT, 1320, 8.2, 168, 8, 2.89, 1, 1, -0.008, -0.117, 0, 0.99, 0.98, 0.935, 0.97, 0.99
+SunBeam IPH, Solar Dynamics SunBeam MT,1320,8.2,168,8,2.89,1,1,-0.008,-0.117,0,0.99,0.98,0.935,0.97,0.99
+SENERtrough-1,ST-1,817.5,5.75,150,12,2.11,1,1,-0.000278005,-0.000042806,0,0.99,0.98,0.935,0.97,0.995
+SENERtrough-2,ST-2,1047,6.87,160,12,2.49,1.1,1,-0.000278005,-0.000042806,0,0.99,0.98,0.935,0.97,0.995
+EuroTrough ET150 - to use,EuroTrough ET150,817.5,5.75,150,12,2.11,1,1,-0.000278005,-0.000042806,0,0.99,0.98,0.935,0.97,0.99


### PR DESCRIPTION
- Add two new SENER collectors to the physical trough collector library
- Update EuroTrough collector values. Files saved with EuroTrough selected will automatically update to the new EuroTrough values. Users will still need to select "apply values" to assign collector library data to any of the 4 collector types used in the annual simulation.