### PR TITLE
Geocode zip to lat/lon for urdb utility rates

### DIFF
--- a/deploy/runtime/webapis.conf
+++ b/deploy/runtime/webapis.conf
@@ -15,7 +15,7 @@ reopt_post=https://developer.nrel.gov/api/reopt/stable/job?format=json&api_key=<
 support_email=mailto:sam.support@nrel.gov
 urdb_ask=https://en.openei.org/w/index.php?title=Special:Ask&q=<QUESTION>&po=<PROPERTIES>&eq=yes&p[format]=json
 urdb_companies_all=https://api.openei.org/utility_companies?version=3&format=json&api_key=<SAMAPIKEY>&scope=<SCOPE>
-urdb_companies_by_zip=https://developer.nrel.gov/api/utility_rates/v3.json?api_key=<SAMAPIKEY>&address=<ADDRESS>
+urdb_companies_by_lat_lon=https://developer.nrel.gov/api/utility_rates/v3.json?api_key=<SAMAPIKEY>&lat=<LAT>&lon=<LON>
 urdb_rates=https://api.openei.org/utility_rates?version=8&format=json&limit=<LIMIT>&detail=<DETAIL>&offset=<OFFSET>&ratesforutility=<UTILITYNAME>&getpage=<GUID>&api_key=<APIKEY>
 urdb_view_rate=https://apps.openei.org/IURDB
 wave_query_west=https://developer.nrel.gov/api/wave/v2/wave/us-west-coast-hindcast-download.csv?api_key=<SAMAPIKEY>&wkt=POINT(<LON>%20<LAT>)&interval=180&email=<USEREMAIL>&attributes=significant_wave_height,energy_period&names=<YEAR>


### PR DESCRIPTION
## Pull Request Template

### Description

See #2034 for description.

Solution is to geocode zip code to lat/lon and then submit lat/lon to URDB API to get list of utility companies. (Geocode API does identify zip codes correctly.)

Fixes #2034 

### Corresponding branches and PRs:

Goes with https://github.com/NREL/SAM-private/pull/123

### Checklist
- [ ] requires help revision and I added that label
- [ ] adds, removes, modifies, or deletes variables in existing compute modules
- [ ] adds a new compute module
- [ ] changes defaults
- [X] I've tagged this PR to a milestone

