### PR TITLE
PV Snow Macro: Fix conversion when snow data expressed in inches

### DIFF
--- a/deploy/runtime/macros/Flat Plate PV/Append Snow Data.lk
+++ b/deploy/runtime/macros/Flat Plate PV/Append Snow Data.lk
@@ -128,7 +128,7 @@ if( mod(weatherLength, 8760) != 0){
 // Load snow data
 
 if( sf_unit == 'cm' ) conversion = 1.0;
-if( sf_unit == 'inch' ) conversion = 2.54;
+if( sf_unit == 'in' ) conversion = 2.54;
 if( sf_unit == 'mm' ) conversion = 0.1;
 if( sf_unit == 'feet' ) conversion = 30.48;
 if( sf_unit == 'meters' ) conversion = 100.0;

--- a/deploy/runtime/macros/PV Battery/Append Snow Data.lk
+++ b/deploy/runtime/macros/PV Battery/Append Snow Data.lk
@@ -128,7 +128,7 @@ if( mod(weatherLength, 8760) != 0){
 // Load snow data
 
 if( sf_unit == 'cm' ) conversion = 1.0;
-if( sf_unit == 'inch' ) conversion = 2.54;
+if( sf_unit == 'in' ) conversion = 2.54;
 if( sf_unit == 'mm' ) conversion = 0.1;
 if( sf_unit == 'feet' ) conversion = 30.48;
 if( sf_unit == 'meters' ) conversion = 100.0;

--- a/deploy/runtime/macros/PVWatts Wind Battery Hybrid/PV Append Snow Data.lk
+++ b/deploy/runtime/macros/PVWatts Wind Battery Hybrid/PV Append Snow Data.lk
@@ -128,7 +128,7 @@ if( mod(weatherLength, 8760) != 0){
 // Load snow data
 
 if( sf_unit == 'cm' ) conversion = 1.0;
-if( sf_unit == 'inch' ) conversion = 2.54;
+if( sf_unit == 'in' ) conversion = 2.54;
 if( sf_unit == 'mm' ) conversion = 0.1;
 if( sf_unit == 'feet' ) conversion = 30.48;
 if( sf_unit == 'meters' ) conversion = 100.0;


### PR DESCRIPTION

### Description

If one attempts to use the macro available in various PV configurations to append snow data measured in inches, the conversion step of the macro will fail with an unintuitive error message. This PR fixes this bug. 

To test:
Create a new PV system. Download a weather file. Download the attached snow data. Attempt to append it to the weather file you download, selecting a header of size 1, a column name of (Observed) Snow Depth (in), and units as inches. The macro will fail. This PR fixes that failure. 

Fixes # (issue(s)): None yet. 

### Corresponding branches and PRs:

None applicable. 

### Unit Test Impact:

None applicable.

### Checklist
- [ ] requires help revision and I added that label
- [ ] adds, removes, modifies, or deletes variables in existing compute modules
- [ ] adds a new compute module
- [ ] changes defaults
- [ ] I've tagged this PR to a milestone


[denver, co_DVNC2_observed_snow_depth.csv](https://github.com/user-attachments/files/19858391/denver.co_DVNC2_observed_snow_depth.csv)
