### PR TITLE
UI: Disable option to not save lifetime variables for PV-Battery systems. 

### DIFF
--- a/deploy/runtime/startup.lk
+++ b/deploy/runtime/startup.lk
@@ -121,7 +121,7 @@ configopt( 'Community Solar', { 'long_name'='Community Solar', 'short_name'='Com
 configopt( 'None', { 'long_name'='No Financial Model', 'short_name'='No financial', 'description'='Run the performance model with no financial model' } );
 
 enum { LOAD_SIMPLE, LOAD_BELPE, NO_LOAD };
-enum { DEGRADATION_AC_SINGLE_YEAR, DEGRADATION_DC_LIFETIME, DEGRADATION_AC_LIFETIME, DEGRADATION_PVSAM, DEGRADATION_PVSAM_LIFETIME};
+enum { DEGRADATION_AC_SINGLE_YEAR, DEGRADATION_DC_LIFETIME, DEGRADATION_AC_LIFETIME, DEGRADATION_PVSAM };
 
 function setup_elec_load_page( mode ) //i is 1 for technologies that HAVE the building load calculator (for now just PV, CSP, Biopower, and Generic Solar- MUST HAVE SOLAR RESOURCE DATA), 2 for techs without ANY load pages (SWH), and 0 for technologies that don't
 {
@@ -311,12 +311,7 @@ function setup_lifetime_page( degradation_mode )
 		addpage( [ [ 'Degradation DC Lifetime', 'Degradation AC DC Lifetime Daily', 'Degradation Lifetime Variables'], ],
                  { 'sidebar'='DC Degradation','help'='degradation_dc' } );
 	}
-    elseif ( degradation_mode == DEGRADATION_PVSAM_LIFETIME)
-	{
-		addpage( [ [ 'Degradation DC Lifetime', 'Degradation AC DC Lifetime Daily' ], ],
-                 { 'sidebar'='DC Degradation','help'='degradation_dc' } );
-	}   
-	// annual AC degradation over one year, 'degradation' requires 'system_use_lifetime = 0'
+     // annual AC degradation over one year, 'degradation' requires 'system_use_lifetime = 0'
      // everything else.
      else // DEGRADATION_AC_SINGLE_YEAR
      {
@@ -2523,7 +2518,7 @@ function setup_pv_battery_pages(is_btm)
 setconfig( 'PV Battery', 'Residential' );
 setmodules( ['belpe', 'pvsamv1', 'grid', 'utilityrate5', 'cashloan']);
 setup_pv_battery_pages(BTM);
-setup_lifetime_page( DEGRADATION_PVSAM_LIFETIME );
+setup_lifetime_page( DEGRADATION_PVSAM );
 addpage( [[ 'PV Battery Capital Costs' ],
 	[ 'PV Battery Capital Cost Curves', 'PV Capex Table', 'PV Capex Table AC', 'PV Capex Table Land', 'PV Capex Table Battery']], { 'sidebar'='Installation Costs', 'help'='cc_pv','exclusive_var'='pv_capex_cost_choice' } );
 addpage( [[ 'Operating Costs PV Battery' ]], {'sidebar' = 'Operating Costs', 'help'='oc_pv-battery'} );
@@ -2532,7 +2527,7 @@ setup_residential_pages( LOAD_BELPE ); //includes building load calculator
 setconfig( 'PV Battery', 'Commercial' );
 setmodules( ['pvsamv1', 'grid', 'utilityrate5', 'cashloan']);
 setup_pv_battery_pages(BTM);
-setup_lifetime_page( DEGRADATION_PVSAM_LIFETIME );
+setup_lifetime_page( DEGRADATION_PVSAM );
 addpage( [[ 'PV Battery Capital Costs' ],
 	[ 'PV Battery Capital Cost Curves', 'PV Capex Table', 'PV Capex Table AC', 'PV Capex Table Land', 'PV Capex Table Battery']], { 'sidebar'='Installation Costs', 'help'='cc_pv','exclusive_var'='pv_capex_cost_choice' } );
 addpage( [[ 'Operating Costs PV Battery' ]], {'sidebar' = 'Operating Costs', 'help'='oc_pv-battery'} );
@@ -2541,13 +2536,13 @@ setup_commercial_pages( LOAD_SIMPLE ); //belpe not valid for commercial
 setconfig( 'PV Battery', 'Third Party' );
 setmodules( ['belpe', 'pvsamv1', 'grid', 'utilityrate5', 'thirdpartyownership']);
 setup_pv_battery_pages(BTM);
-setup_lifetime_page( DEGRADATION_PVSAM_LIFETIME );
+setup_lifetime_page( DEGRADATION_PVSAM );
 setup_thirdparty_pages( LOAD_BELPE ); //includes building load calculator by default in this function
 
 setconfig( 'PV Battery', 'Host Developer' );
 setmodules( ['pvsamv1', 'grid', 'utilityrate5', 'host_developer']);
 setup_pv_battery_pages(BTM);
-setup_lifetime_page( DEGRADATION_PVSAM_LIFETIME );
+setup_lifetime_page( DEGRADATION_PVSAM );
 addpage( [[ 'PV Battery Capital Costs' ],
 		[ 'PV Battery Capital Cost Curves', 'PV Capex Table', 'PV Capex Table AC', 'PV Capex Table Land', 'PV Capex Table Battery']], { 'sidebar'='Installation Costs', 'help'='cc_pv','exclusive_var'='pv_capex_cost_choice' } );
 addpage( [[ 'Operating Costs PV Battery' ]], {'sidebar' = 'Operating Costs', 'help'='oc_pv-battery'} );
@@ -2556,7 +2551,7 @@ setup_host_developer_pages( LOAD_SIMPLE ); //includes building load calculator b
 setconfig( 'PV Battery', 'Single Owner' );
 setmodules( ['pvsamv1', 'grid', 'utilityrate5', 'singleowner']);
 setup_pv_battery_pages(FOM);
-setup_lifetime_page( DEGRADATION_PVSAM_LIFETIME );
+setup_lifetime_page( DEGRADATION_PVSAM );
 addpage( [[ 'PV Battery Capital Costs' ],
 		[ 'PV Battery Capital Cost Curves', 'PV Capex Table', 'PV Capex Table AC', 'PV Capex Table Land', 'PV Capex Table Battery']], { 'sidebar'='Installation Costs', 'help'='cc_pv','exclusive_var'='pv_capex_cost_choice' } );
 addpage( [[ 'Operating Costs PV Battery', 'Operating Costs Land Lease' ]], {'sidebar' = 'Operating Costs', 'help'='oc_pv-battery'} );
@@ -2566,7 +2561,7 @@ setup_electricity_purchases();
 setconfig( 'PV Battery', 'Merchant Plant' );
 setmodules( ['pvsamv1', 'grid', 'utilityrate5', 'merchantplant']);
 setup_pv_battery_pages(FOM);
-setup_lifetime_page( DEGRADATION_PVSAM_LIFETIME );
+setup_lifetime_page( DEGRADATION_PVSAM );
 addpage( [[ 'PV Battery Capital Costs' ],
 		[ 'PV Battery Capital Cost Curves', 'PV Capex Table', 'PV Capex Table AC', 'PV Capex Table Land', 'PV Capex Table Battery']], { 'sidebar'='Installation Costs', 'help'='cc_pv','exclusive_var'='pv_capex_cost_choice' } );
 addpage( [[ 'Operating Costs PV Battery', 'Operating Costs Land Lease' ]], {'sidebar' = 'Operating Costs', 'help'='oc_pv-battery'} );
@@ -2576,7 +2571,7 @@ setup_electricity_purchases();
 setconfig( 'PV Battery', 'Leveraged Partnership Flip' );
 setmodules( ['pvsamv1', 'grid', 'utilityrate5', 'levpartflip']);
 setup_pv_battery_pages(FOM);
-setup_lifetime_page( DEGRADATION_PVSAM_LIFETIME );
+setup_lifetime_page( DEGRADATION_PVSAM );
 addpage( [[ 'PV Battery Capital Costs' ],
 		[ 'PV Battery Capital Cost Curves', 'PV Capex Table', 'PV Capex Table AC', 'PV Capex Table Land', 'PV Capex Table Battery']], { 'sidebar'='Installation Costs', 'help'='cc_pv','exclusive_var'='pv_capex_cost_choice' } );
 addpage( [[ 'Operating Costs PV Battery', 'Operating Costs Land Lease' ]], {'sidebar' = 'Operating Costs', 'help'='oc_pv-battery'} );
@@ -2586,7 +2581,7 @@ setup_electricity_purchases();
 setconfig( 'PV Battery', 'All Equity Partnership Flip' );
 setmodules( ['pvsamv1', 'grid', 'utilityrate5', 'equpartflip']);
 setup_pv_battery_pages(FOM);
-setup_lifetime_page( DEGRADATION_PVSAM_LIFETIME );
+setup_lifetime_page( DEGRADATION_PVSAM );
 addpage( [[ 'PV Battery Capital Costs' ],
 		[ 'PV Battery Capital Cost Curves', 'PV Capex Table', 'PV Capex Table AC', 'PV Capex Table Land', 'PV Capex Table Battery']], { 'sidebar'='Installation Costs', 'help'='cc_pv','exclusive_var'='pv_capex_cost_choice' } );
 addpage( [[ 'Operating Costs PV Battery', 'Operating Costs Land Lease' ]], {'sidebar' = 'Operating Costs', 'help'='oc_pv-battery'} );
@@ -2596,7 +2591,7 @@ setup_electricity_purchases();
 setconfig( 'PV Battery', 'Sale Leaseback' );
 setmodules( ['pvsamv1', 'grid', 'utilityrate5', 'saleleaseback']);
 setup_pv_battery_pages(FOM);
-setup_lifetime_page( DEGRADATION_PVSAM_LIFETIME );
+setup_lifetime_page( DEGRADATION_PVSAM );
 addpage( [[ 'PV Battery Capital Costs' ],
 		[ 'PV Battery Capital Cost Curves', 'PV Capex Table', 'PV Capex Table AC', 'PV Capex Table Land', 'PV Capex Table Battery']], { 'sidebar'='Installation Costs', 'help'='cc_pv','exclusive_var'='pv_capex_cost_choice' } );
 addpage( [[ 'Operating Costs PV Battery', 'Operating Costs Land Lease' ]], {'sidebar' = 'Operating Costs', 'help'='oc_pv-battery'} );

--- a/deploy/runtime/startup.lk
+++ b/deploy/runtime/startup.lk
@@ -121,7 +121,7 @@ configopt( 'Community Solar', { 'long_name'='Community Solar', 'short_name'='Com
 configopt( 'None', { 'long_name'='No Financial Model', 'short_name'='No financial', 'description'='Run the performance model with no financial model' } );
 
 enum { LOAD_SIMPLE, LOAD_BELPE, NO_LOAD };
-enum { DEGRADATION_AC_SINGLE_YEAR, DEGRADATION_DC_LIFETIME, DEGRADATION_AC_LIFETIME, DEGRADATION_PVSAM };
+enum { DEGRADATION_AC_SINGLE_YEAR, DEGRADATION_DC_LIFETIME, DEGRADATION_AC_LIFETIME, DEGRADATION_PVSAM, DEGRADATION_PVSAM_LIFETIME};
 
 function setup_elec_load_page( mode ) //i is 1 for technologies that HAVE the building load calculator (for now just PV, CSP, Biopower, and Generic Solar- MUST HAVE SOLAR RESOURCE DATA), 2 for techs without ANY load pages (SWH), and 0 for technologies that don't
 {
@@ -311,7 +311,12 @@ function setup_lifetime_page( degradation_mode )
 		addpage( [ [ 'Degradation DC Lifetime', 'Degradation AC DC Lifetime Daily', 'Degradation Lifetime Variables'], ],
                  { 'sidebar'='DC Degradation','help'='degradation_dc' } );
 	}
-     // annual AC degradation over one year, 'degradation' requires 'system_use_lifetime = 0'
+    elseif ( degradation_mode == DEGRADATION_PVSAM_LIFETIME)
+	{
+		addpage( [ [ 'Degradation DC Lifetime', 'Degradation AC DC Lifetime Daily' ], ],
+                 { 'sidebar'='DC Degradation','help'='degradation_dc' } );
+	}   
+	// annual AC degradation over one year, 'degradation' requires 'system_use_lifetime = 0'
      // everything else.
      else // DEGRADATION_AC_SINGLE_YEAR
      {
@@ -2518,7 +2523,7 @@ function setup_pv_battery_pages(is_btm)
 setconfig( 'PV Battery', 'Residential' );
 setmodules( ['belpe', 'pvsamv1', 'grid', 'utilityrate5', 'cashloan']);
 setup_pv_battery_pages(BTM);
-setup_lifetime_page( DEGRADATION_PVSAM );
+setup_lifetime_page( DEGRADATION_PVSAM_LIFETIME );
 addpage( [[ 'PV Battery Capital Costs' ],
 	[ 'PV Battery Capital Cost Curves', 'PV Capex Table', 'PV Capex Table AC', 'PV Capex Table Land', 'PV Capex Table Battery']], { 'sidebar'='Installation Costs', 'help'='cc_pv','exclusive_var'='pv_capex_cost_choice' } );
 addpage( [[ 'Operating Costs PV Battery' ]], {'sidebar' = 'Operating Costs', 'help'='oc_pv-battery'} );
@@ -2527,7 +2532,7 @@ setup_residential_pages( LOAD_BELPE ); //includes building load calculator
 setconfig( 'PV Battery', 'Commercial' );
 setmodules( ['pvsamv1', 'grid', 'utilityrate5', 'cashloan']);
 setup_pv_battery_pages(BTM);
-setup_lifetime_page( DEGRADATION_PVSAM );
+setup_lifetime_page( DEGRADATION_PVSAM_LIFETIME );
 addpage( [[ 'PV Battery Capital Costs' ],
 	[ 'PV Battery Capital Cost Curves', 'PV Capex Table', 'PV Capex Table AC', 'PV Capex Table Land', 'PV Capex Table Battery']], { 'sidebar'='Installation Costs', 'help'='cc_pv','exclusive_var'='pv_capex_cost_choice' } );
 addpage( [[ 'Operating Costs PV Battery' ]], {'sidebar' = 'Operating Costs', 'help'='oc_pv-battery'} );
@@ -2536,13 +2541,13 @@ setup_commercial_pages( LOAD_SIMPLE ); //belpe not valid for commercial
 setconfig( 'PV Battery', 'Third Party' );
 setmodules( ['belpe', 'pvsamv1', 'grid', 'utilityrate5', 'thirdpartyownership']);
 setup_pv_battery_pages(BTM);
-setup_lifetime_page( DEGRADATION_PVSAM );
+setup_lifetime_page( DEGRADATION_PVSAM_LIFETIME );
 setup_thirdparty_pages( LOAD_BELPE ); //includes building load calculator by default in this function
 
 setconfig( 'PV Battery', 'Host Developer' );
 setmodules( ['pvsamv1', 'grid', 'utilityrate5', 'host_developer']);
 setup_pv_battery_pages(BTM);
-setup_lifetime_page( DEGRADATION_PVSAM );
+setup_lifetime_page( DEGRADATION_PVSAM_LIFETIME );
 addpage( [[ 'PV Battery Capital Costs' ],
 		[ 'PV Battery Capital Cost Curves', 'PV Capex Table', 'PV Capex Table AC', 'PV Capex Table Land', 'PV Capex Table Battery']], { 'sidebar'='Installation Costs', 'help'='cc_pv','exclusive_var'='pv_capex_cost_choice' } );
 addpage( [[ 'Operating Costs PV Battery' ]], {'sidebar' = 'Operating Costs', 'help'='oc_pv-battery'} );
@@ -2551,7 +2556,7 @@ setup_host_developer_pages( LOAD_SIMPLE ); //includes building load calculator b
 setconfig( 'PV Battery', 'Single Owner' );
 setmodules( ['pvsamv1', 'grid', 'utilityrate5', 'singleowner']);
 setup_pv_battery_pages(FOM);
-setup_lifetime_page( DEGRADATION_PVSAM );
+setup_lifetime_page( DEGRADATION_PVSAM_LIFETIME );
 addpage( [[ 'PV Battery Capital Costs' ],
 		[ 'PV Battery Capital Cost Curves', 'PV Capex Table', 'PV Capex Table AC', 'PV Capex Table Land', 'PV Capex Table Battery']], { 'sidebar'='Installation Costs', 'help'='cc_pv','exclusive_var'='pv_capex_cost_choice' } );
 addpage( [[ 'Operating Costs PV Battery', 'Operating Costs Land Lease' ]], {'sidebar' = 'Operating Costs', 'help'='oc_pv-battery'} );
@@ -2561,7 +2566,7 @@ setup_electricity_purchases();
 setconfig( 'PV Battery', 'Merchant Plant' );
 setmodules( ['pvsamv1', 'grid', 'utilityrate5', 'merchantplant']);
 setup_pv_battery_pages(FOM);
-setup_lifetime_page( DEGRADATION_PVSAM );
+setup_lifetime_page( DEGRADATION_PVSAM_LIFETIME );
 addpage( [[ 'PV Battery Capital Costs' ],
 		[ 'PV Battery Capital Cost Curves', 'PV Capex Table', 'PV Capex Table AC', 'PV Capex Table Land', 'PV Capex Table Battery']], { 'sidebar'='Installation Costs', 'help'='cc_pv','exclusive_var'='pv_capex_cost_choice' } );
 addpage( [[ 'Operating Costs PV Battery', 'Operating Costs Land Lease' ]], {'sidebar' = 'Operating Costs', 'help'='oc_pv-battery'} );
@@ -2571,7 +2576,7 @@ setup_electricity_purchases();
 setconfig( 'PV Battery', 'Leveraged Partnership Flip' );
 setmodules( ['pvsamv1', 'grid', 'utilityrate5', 'levpartflip']);
 setup_pv_battery_pages(FOM);
-setup_lifetime_page( DEGRADATION_PVSAM );
+setup_lifetime_page( DEGRADATION_PVSAM_LIFETIME );
 addpage( [[ 'PV Battery Capital Costs' ],
 		[ 'PV Battery Capital Cost Curves', 'PV Capex Table', 'PV Capex Table AC', 'PV Capex Table Land', 'PV Capex Table Battery']], { 'sidebar'='Installation Costs', 'help'='cc_pv','exclusive_var'='pv_capex_cost_choice' } );
 addpage( [[ 'Operating Costs PV Battery', 'Operating Costs Land Lease' ]], {'sidebar' = 'Operating Costs', 'help'='oc_pv-battery'} );
@@ -2581,7 +2586,7 @@ setup_electricity_purchases();
 setconfig( 'PV Battery', 'All Equity Partnership Flip' );
 setmodules( ['pvsamv1', 'grid', 'utilityrate5', 'equpartflip']);
 setup_pv_battery_pages(FOM);
-setup_lifetime_page( DEGRADATION_PVSAM );
+setup_lifetime_page( DEGRADATION_PVSAM_LIFETIME );
 addpage( [[ 'PV Battery Capital Costs' ],
 		[ 'PV Battery Capital Cost Curves', 'PV Capex Table', 'PV Capex Table AC', 'PV Capex Table Land', 'PV Capex Table Battery']], { 'sidebar'='Installation Costs', 'help'='cc_pv','exclusive_var'='pv_capex_cost_choice' } );
 addpage( [[ 'Operating Costs PV Battery', 'Operating Costs Land Lease' ]], {'sidebar' = 'Operating Costs', 'help'='oc_pv-battery'} );
@@ -2591,7 +2596,7 @@ setup_electricity_purchases();
 setconfig( 'PV Battery', 'Sale Leaseback' );
 setmodules( ['pvsamv1', 'grid', 'utilityrate5', 'saleleaseback']);
 setup_pv_battery_pages(FOM);
-setup_lifetime_page( DEGRADATION_PVSAM );
+setup_lifetime_page( DEGRADATION_PVSAM_LIFETIME );
 addpage( [[ 'PV Battery Capital Costs' ],
 		[ 'PV Battery Capital Cost Curves', 'PV Capex Table', 'PV Capex Table AC', 'PV Capex Table Land', 'PV Capex Table Battery']], { 'sidebar'='Installation Costs', 'help'='cc_pv','exclusive_var'='pv_capex_cost_choice' } );
 addpage( [[ 'Operating Costs PV Battery', 'Operating Costs Land Lease' ]], {'sidebar' = 'Operating Costs', 'help'='oc_pv-battery'} );

--- a/deploy/runtime/ui/Degradation AC DC Lifetime Daily.json
+++ b/deploy/runtime/ui/Degradation AC DC Lifetime Daily.json
@@ -12,7 +12,7 @@
                 },
                 "X": {
                     "Type": 3.0,
-                    "Integer": 258.0
+                    "Integer": 243.0
                 },
                 "Y": {
                     "Type": 3.0,
@@ -77,7 +77,7 @@
                 },
                 "X": {
                     "Type": 3.0,
-                    "Integer": 258.0
+                    "Integer": 243.0
                 },
                 "Y": {
                     "Type": 3.0,
@@ -150,7 +150,7 @@
                 },
                 "Width": {
                     "Type": 3.0,
-                    "Integer": 231.0
+                    "Integer": 213.0
                 },
                 "Height": {
                     "Type": 3.0,
@@ -191,7 +191,7 @@
                 },
                 "Width": {
                     "Type": 3.0,
-                    "Integer": 231.0
+                    "Integer": 213.0
                 },
                 "Height": {
                     "Type": 3.0,
@@ -261,7 +261,7 @@
                 },
                 "X": {
                     "Type": 3.0,
-                    "Integer": 450.0
+                    "Integer": 438.0
                 },
                 "Y": {
                     "Type": 3.0,

--- a/deploy/runtime/ui/Degradation AC Lifetime.json
+++ b/deploy/runtime/ui/Degradation AC Lifetime.json
@@ -1,7 +1,7 @@
 {
     "Name": "Degradation AC Lifetime",
-    "Width": 792.0,
-    "Height": 135.0,
+    "Width": 794.0,
+    "Height": 134.0,
     "FormObjects": {
         "GroupBox": {
             "Visible": 1.0,
@@ -164,7 +164,7 @@
                 },
                 "X": {
                     "Type": 3.0,
-                    "Integer": 417.0
+                    "Integer": 438.0
                 },
                 "Y": {
                     "Type": 3.0,
@@ -172,7 +172,7 @@
                 },
                 "Width": {
                     "Type": 3.0,
-                    "Integer": 360.0
+                    "Integer": 345.0
                 },
                 "Height": {
                     "Type": 3.0,

--- a/deploy/runtime/ui/Degradation AC Single Year.json
+++ b/deploy/runtime/ui/Degradation AC Single Year.json
@@ -1,7 +1,7 @@
 {
     "Name": "Degradation AC Single Year",
     "Width": 788.0,
-    "Height": 146.0,
+    "Height": 132.0,
     "FormObjects": {
         "GroupBox": {
             "Visible": 1.0,
@@ -24,7 +24,7 @@
                 },
                 "Height": {
                     "Type": 3.0,
-                    "Integer": 137.0
+                    "Integer": 122.0
                 },
                 "Tool Tip": {
                     "Type": 5.0,
@@ -53,7 +53,7 @@
                 },
                 "Y": {
                     "Type": 3.0,
-                    "Integer": 111.0
+                    "Integer": 96.0
                 },
                 "Width": {
                     "Type": 3.0,
@@ -164,7 +164,7 @@
                 },
                 "X": {
                     "Type": 3.0,
-                    "Integer": 441.0
+                    "Integer": 438.0
                 },
                 "Y": {
                     "Type": 3.0,
@@ -176,7 +176,7 @@
                 },
                 "Height": {
                     "Type": 3.0,
-                    "Integer": 87.0
+                    "Integer": 72.0
                 },
                 "Tool Tip": {
                     "Type": 5.0,

--- a/deploy/runtime/ui/Degradation DC Lifetime.json
+++ b/deploy/runtime/ui/Degradation DC Lifetime.json
@@ -1,7 +1,7 @@
 {
     "Name": "Degradation DC Lifetime",
     "Width": 788.0,
-    "Height": 146.0,
+    "Height": 132.0,
     "FormObjects": {
         "GroupBox": {
             "Visible": 1.0,
@@ -24,7 +24,7 @@
                 },
                 "Height": {
                     "Type": 3.0,
-                    "Integer": 140.0
+                    "Integer": 122.0
                 },
                 "Tool Tip": {
                     "Type": 5.0,
@@ -106,7 +106,7 @@
                 },
                 "Y": {
                     "Type": 3.0,
-                    "Integer": 111.0
+                    "Integer": 90.0
                 },
                 "Width": {
                     "Type": 3.0,
@@ -176,7 +176,7 @@
                 },
                 "Height": {
                     "Type": 3.0,
-                    "Integer": 51.0
+                    "Integer": 27.0
                 },
                 "Tool Tip": {
                     "Type": 5.0,
@@ -238,7 +238,7 @@
                 },
                 "Height": {
                     "Type": 3.0,
-                    "Integer": 90.0
+                    "Integer": 66.0
                 },
                 "Tool Tip": {
                     "Type": 5.0,

--- a/deploy/runtime/ui/Degradation Lifetime Variables.json
+++ b/deploy/runtime/ui/Degradation Lifetime Variables.json
@@ -3,6 +3,68 @@
     "Width": 787.0,
     "Height": 135.0,
     "FormObjects": {
+        "Label": {
+            "Visible": 1.0,
+            "ObjectProperties": {
+                "Name": {
+                    "Type": 5.0,
+                    "String": "batt_warning"
+                },
+                "X": {
+                    "Type": 3.0,
+                    "Integer": 438.0
+                },
+                "Y": {
+                    "Type": 3.0,
+                    "Integer": 27.0
+                },
+                "Width": {
+                    "Type": 3.0,
+                    "Integer": 90.0
+                },
+                "Height": {
+                    "Type": 3.0,
+                    "Integer": 24.0
+                },
+                "Tool Tip": {
+                    "Type": 5.0,
+                    "String": ""
+                },
+                "Caption": {
+                    "Type": 5.0,
+                    "String": ""
+                },
+                "TextColour": {
+                    "Type": 4.0,
+                    "Color": {
+                        "Red": 255.0,
+                        "Green": 0.0,
+                        "Blue": 0.0,
+                        "Alpha": 255.0
+                    }
+                },
+                "Bold": {
+                    "Type": 2.0,
+                    "Boolean": 0.0
+                },
+                "FontSize": {
+                    "Type": 3.0,
+                    "Integer": 0.0
+                },
+                "WordWrap": {
+                    "Type": 2.0,
+                    "Boolean": 0.0
+                },
+                "AlignRight": {
+                    "Type": 2.0,
+                    "Boolean": 0.0
+                },
+                "AlignTop": {
+                    "Type": 2.0,
+                    "Boolean": 0.0
+                }
+            }
+        },
         "GroupBox": {
             "Visible": 1.0,
             "ObjectProperties": {
@@ -53,7 +115,7 @@
                 },
                 "Y": {
                     "Type": 3.0,
-                    "Integer": 54.0
+                    "Integer": 57.0
                 },
                 "Width": {
                     "Type": 3.0,
@@ -160,5 +222,15 @@
         }
     },
     "Equations": [],
-    "Callbacks": []
+    "Callbacks": [
+        "on_load{'Degradation Lifetime Variables'} = define()\r",
+        "{\r",
+        "\tif ( technology() == 'PV Battery' ) { \r",
+        "\t\tenable('save_full_lifetime_variables', 0); \r",
+        "\t\tproperty('batt_warning',\r",
+        "\t\t'Caption',\"This option must be enabled for PV Battery simulations\");\r",
+        "\t\t\r",
+        "\t}\r",
+        "};"
+    ]
 }

--- a/deploy/runtime/ui/Degradation Lifetime Variables.json
+++ b/deploy/runtime/ui/Degradation Lifetime Variables.json
@@ -1,7 +1,7 @@
 {
     "Name": "Degradation Lifetime Variables",
-    "Width": 787.0,
-    "Height": 135.0,
+    "Width": 788.0,
+    "Height": 126.0,
     "FormObjects": {
         "Label": {
             "Visible": 1.0,
@@ -20,7 +20,7 @@
                 },
                 "Width": {
                     "Type": 3.0,
-                    "Integer": 90.0
+                    "Integer": 342.0
                 },
                 "Height": {
                     "Type": 3.0,
@@ -37,7 +37,7 @@
                 "TextColour": {
                     "Type": 4.0,
                     "Color": {
-                        "Red": 255.0,
+                        "Red": 0.0,
                         "Green": 0.0,
                         "Blue": 0.0,
                         "Alpha": 255.0
@@ -53,7 +53,7 @@
                 },
                 "WordWrap": {
                     "Type": 2.0,
-                    "Boolean": 0.0
+                    "Boolean": 1.0
                 },
                 "AlignRight": {
                     "Type": 2.0,
@@ -61,7 +61,7 @@
                 },
                 "AlignTop": {
                     "Type": 2.0,
-                    "Boolean": 0.0
+                    "Boolean": 1.0
                 }
             }
         },
@@ -86,7 +86,7 @@
                 },
                 "Height": {
                     "Type": 3.0,
-                    "Integer": 130.0
+                    "Integer": 118.0
                 },
                 "Tool Tip": {
                     "Type": 5.0,
@@ -111,7 +111,7 @@
                 },
                 "X": {
                     "Type": 3.0,
-                    "Integer": 21.0
+                    "Integer": 18.0
                 },
                 "Y": {
                     "Type": 3.0,
@@ -119,11 +119,11 @@
                 },
                 "Width": {
                     "Type": 3.0,
-                    "Integer": 760.0
+                    "Integer": 763.0
                 },
                 "Height": {
                     "Type": 3.0,
-                    "Integer": 74.0
+                    "Integer": 56.0
                 },
                 "Tool Tip": {
                     "Type": 5.0,
@@ -228,8 +228,7 @@
         "\tif ( technology() == 'PV Battery' ) { \r",
         "\t\tenable('save_full_lifetime_variables', 0); \r",
         "\t\tproperty('batt_warning',\r",
-        "\t\t'Caption',\"This option must be enabled for PV Battery simulations\");\r",
-        "\t\t\r",
+        "\t\t'Caption',\"This option must be enabled for PV Battery configurations.\");\r",
         "\t}\r",
         "};"
     ]


### PR DESCRIPTION
### Description

[SAM#2008](https://github.com/NREL/sam/issues/2008) describes a bug in which deselecting the option to save lifetime variables in a PV-Battery simulation leads SAM to crash. The underlying cause of the crash is described more thoroughly in the SAM issue, but briefly, it is a heap corruption bug caused by the smaller, non-lifetime allocations being too small to compute figures for the battery in cmod_pvsamv1.cpp.

This fixes this issue on the UI side by preventing users from deselecting the option to save lifetime variables for PV-Battery systems. It also provides a brief warning why this option is disabled. 

Fixes # (issue(s))
#2008 

### Corresponding branches and PRs:
[ssc/SAM_2008](https://github.com/NREL/ssc/pull/1334)


### Unit Test Impact:

Tests shouldn't be impacted. 

### Checklist
- [ ] requires help revision and I added that label
- [ ] adds, removes, modifies, or deletes variables in existing compute modules
- [ ] adds a new compute module
- [ ] changes defaults
- [ ] I've tagged this PR to a milestone


