### PR TITLE
Parametrics: Ensure initialization before attempting to read or copy runs

### DIFF
--- a/src/parametric.h
+++ b/src/parametric.h
@@ -123,6 +123,7 @@ public:
 	void Init();
 	void UpdateSetup();
 	void UpdateView();
+	std::vector<Simulation*> PrepareSimulations();
 
 	wxArrayString GetInputNames();
 	wxArrayString GetOutputNames();

--- a/src/simulation.h
+++ b/src/simulation.h
@@ -185,6 +185,9 @@ public:
 	// SSC compute module execution time only
 	int GetSSCElapsedTime() { return m_sscElapsedMsec; }
 
+	// size of input, useful for checking if initialized already
+	size_t GetInputSize() { return m_inputs.size(); } const
+
 	wxArrayString GetModels() { return m_simlist; }
 	bool SetModels(); // sets m_simlist - also done in Prepare
 


### PR DESCRIPTION
### Description

#2013 reports a bug in which creating new cases from parametric runs leads to a crash if the parametric runs haven't actually been simulated. 

@cpaulgilman 's steps to reproduce:

> Open .sam file in [parametric-test.zip](https://github.com/user-attachments/files/18873374/parametric-test.zip).
>     Click Parametrics.
>     Right-click any row header and click Create new case*.
>     SAM crashes.

I note that the crash also occurs if one chooses "Show inputs". The cause of this issue, and the solution, are the same as for the original reported issue. 

This bug is caused by attempting to read uninitialized data. 

This PR solves this problem by checking for initialization before this read, and if uninitialized, initializes. 

Fixes #2013 

### Corresponding branches and PRs:

This is a SAM-only change. 

### Unit Test Impact:

No unit test impact. 
### Checklist
- [ ] requires help revision and I added that label
- [ ] adds, removes, modifies, or deletes variables in existing compute modules
- [ ] adds a new compute module
- [ ] changes defaults
- [ ] I've tagged this PR to a milestone

