### PR TITLE
Migrate Bing Maps API to Azure Maps API

### DIFF
--- a/deploy/runtime/ui/Solar Resource Data.json
+++ b/deploy/runtime/ui/Solar Resource Data.json
@@ -3841,8 +3841,6 @@
         "\t\t{\r",
         "\t\t\tlocation = loc_test.address;\r",
         "\t\t\tg = geocode( location );\r",
-        "\t\t\t// sometimes correct address fails but works on second try\r",
-        "\t\t\tif ( !g.ok ) { g = geocode( location ); }\r",
         "\t\t\tif ( g.ok ) \r",
         "\t\t\t{\r",
         "\t\t\t\tlat = g.lat;\r",

--- a/src/geotools.cpp
+++ b/src/geotools.cpp
@@ -193,7 +193,6 @@ bool GeoTools::GeocodeDeveloper(const wxString& address, double* lat, double* lo
     curl.AddHttpHeader("Content-Type: application/json");
     curl.AddHttpHeader("Accept: application/json");
 
-
     if (showprogress) {
         if (!curl.Get(url, "Geocoding address '" + address + "'..."))
             return false;
@@ -203,26 +202,11 @@ bool GeoTools::GeocodeDeveloper(const wxString& address, double* lat, double* lo
             return false;
     }
  
-    // change from UTF8 to UTF16 encoding to address unicode characters per SAM GitHub issue 1848
+    // change from UTF8 to UTF16 encoding to address unicode characters per SAM issue 1848
     rapidjson::GenericDocument < rapidjson::UTF16<> > reader;
     wxString str = curl.GetDataAsString();
 
     rapidjson::ParseResult ok = reader.Parse(str.c_str());
-
-
-    /* 
-    example for "denver, co"
-{"info":
-    {"statuscode":0,"copyright":
-        {"text":"© 2024 MapQuest, Inc.","imageUrl":"http://api.mqcdn.com/res/mqlogo.gif","imageAltText":"© 2024 MapQuest, Inc."}
-    ,"messages":[]}
-    ,"options":{"maxResults":-1,"ignoreLatLngInput":false}
-    ,"results":
-    [{"providedLocation":{"location":"denver co"},"locations":
-        [{"street":"","adminArea6":"","adminArea6Type":"Neighborhood","adminArea5":"Denver","adminArea5Type":"City","adminArea4":"Denver","adminArea4Type":"County","adminArea3":"CO","adminArea3Type":"State","adminArea1":"US","adminArea1Type":"Country","postalCode":"","geocodeQualityCode":"A5XAX","geocodeQuality":"CITY","dragPoint":false,"sideOfStreet":"N","linkId":"0","unknownInput":"","type":"s","latLng":{"lat":39.74001,"lng":-104.99202},"displayLatLng":{"lat":39.74001,"lng":-104.99202},"mapUrl":""}]
-    }
-]}
-        */
 
     if (!reader.HasParseError()) {
         if (reader.HasMember(L"results")) {
@@ -233,21 +217,21 @@ bool GeoTools::GeocodeDeveloper(const wxString& address, double* lat, double* lo
                             if (reader[L"results"][0][L"locations"][0][L"latLng"].HasMember(L"lat")) {
                                 if (reader[L"results"][0][L"locations"][0][L"latLng"][L"lat"].IsNumber()) {
                                     *lat = reader[L"results"][0][L"locations"][0][L"latLng"][L"lat"].GetDouble();
-                                    success = true;
+                                    if (reader[L"results"][0][L"locations"][0][L"latLng"].HasMember(L"lng")) {
+                                        if (reader[L"results"][0][L"locations"][0][L"latLng"][L"lng"].IsNumber()) {
+                                            *lon = reader[L"results"][0][L"locations"][0][L"latLng"][L"lng"].GetDouble();
+                                            success = true; // only if lat and lon are numbers
+                                        }
+                                    }
+
                                 }
                             }
-                            if (reader[L"results"][0][L"locations"][0][L"latLng"].HasMember(L"lng")) {
-                                if (reader[L"results"][0][L"locations"][0][L"latLng"][L"lng"].IsNumber()) {
-                                    *lon = reader[L"results"][0][L"locations"][0][L"latLng"][L"lng"].GetDouble();
-                                    success &= true;
-                                }
-                            }
-                        }
+                         }
                     }
                 }
             }
         }
-        // check status code
+/*        // check status code
         success = false;//overrides success of retrieving data
 
         if (reader.HasMember(L"info")) {
@@ -257,6 +241,7 @@ bool GeoTools::GeocodeDeveloper(const wxString& address, double* lat, double* lo
                 }
             }
         }
+*/  
     }
     else {
         wxMessageBox(rapidjson::GetParseError_En(ok.Code()), "geocode developer parse error ");
@@ -265,16 +250,14 @@ bool GeoTools::GeocodeDeveloper(const wxString& address, double* lat, double* lo
     if (!success)
         return false;
 
+    // time zone is optional
     if (tz != 0) 
     {
         success = false;
 
         curl = wxEasyCurl();
 
-        // replace bing api with azure maps api
-        //url = SamApp::WebApi("bing_maps_timezone_api");
-        //url.Replace("<POINT>", wxString::Format("%.14lf,%.14lf", *lat, *lon));
-        //url.Replace("<BINGAPIKEY>", wxString(bing_api_key));
+        // azure maps time zone api
         url = SamApp::WebApi("azure_maps_timezone_api");
         url.Replace("<LATLON>", wxString::Format("%.14lf,%.14lf", *lat, *lon));
         url.Replace("<AZUREAPIKEY>", wxString(azure_api_key));
@@ -282,20 +265,30 @@ bool GeoTools::GeocodeDeveloper(const wxString& address, double* lat, double* lo
         curl.AddHttpHeader("Content-Type: application/json");
         curl.AddHttpHeader("Accept: application/json");
 
-        if (showprogress) 
-        {
-            if (!curl.Get(url, "Geocoding address '" + address + "'..."))
-                return false;
+        if (showprogress) {
+            curl.Get(url, "Getting time zone '" + address + "'...");
         }
         else {
-            if (!curl.Get(url))
-                return false;
+            curl.Get(url);
         }
 
         str = curl.GetDataAsString();
 
         reader.Parse(str.c_str());
 
+        if (reader.HasMember(L"error")) {
+            if (reader[L"error"].HasMember(L"code")) {
+                if (reader[L"error"][L"code"].IsString()) {
+                    wxString str = reader[L"error"][L"code"].GetString();
+                    if (str.Lower() != "") {
+                        wxMessageBox(wxString::Format("Time Zone API Error!\n%s", str));
+                        return false;
+                    } 
+                }
+            }
+        }
+
+        *tz = NULL;
         if (!reader.HasParseError()) {
             if (reader.HasMember(L"TimeZones")) {
                 if (reader[L"TimeZones"].IsArray()) {
@@ -304,7 +297,7 @@ bool GeoTools::GeocodeDeveloper(const wxString& address, double* lat, double* lo
                             if (reader[L"TimeZones"][0][L"ReferenceTime"][L"StandardOffset"].IsString()) {
                                 wxString stz = reader[L"TimeZones"][0][L"ReferenceTime"][L"StandardOffset"].GetString();
                                 wxArrayString as = wxSplit(stz, ':');
-                                if (as.Count() != 2) return false;
+                                if (as.Count() != 3) return false; // example "-08:00:00"
                                 if (!as[0].ToDouble(tz)) return false;
                                 double offset = 0;
                                 if (as[1] == "30") offset = 0.5;
@@ -318,28 +311,25 @@ bool GeoTools::GeocodeDeveloper(const wxString& address, double* lat, double* lo
                     }
                 }
             }
-            // check status code
-            success = false;//overrides success of retrieving data
-
-            // TO DO improve error handling
-            if (reader.HasMember(L"error")) {
-                if (reader[L"error"].HasMember(L"code")) {
-                    if (reader[L"error"][L"code"].IsString()) {
-                        wxString str = reader[L"error"][L"code"].GetString();
-                        success = str.Lower() != "";
-                    }
-                }
-            }
         }
-
+        else { // parse error
+            wxMessageBox(wxString::Format("Time Zone API Error!\nFailed to parse response."));
+            success = false;
+        }
     }
     return success;
-}
+ }
 
 
 wxBitmap GeoTools::StaticMap(double lat, double lon, int zoom, MapProvider service) {
-    if (zoom > 21) zoom = 21;
-    if (zoom < 1) zoom = 1;
+
+    rapidjson::GenericDocument < rapidjson::UTF16<> > reader;
+    wxString str;
+
+    // Azure get static map documentation https://learn.microsoft.com/en-us/rest/api/maps/render/get-map-static-image
+    // valid zoom range is 0-19 for tilesetId = microsoft.imagery 
+    if (zoom > 19) zoom = 21;
+    if (zoom < 0) zoom = 0;
     wxString zoomStr = wxString::Format("%d", zoom);
 
     wxString url;
@@ -351,14 +341,46 @@ wxBitmap GeoTools::StaticMap(double lat, double lon, int zoom, MapProvider servi
 
     }
     else {
-        url = SamApp::WebApi("bing_maps_imagery_api");
+        url = SamApp::WebApi("azure_maps_static_map_api");
         url.Replace("<POINT>", wxString::Format("%.14lf,%.14lf", lat, lon));
         url.Replace("<ZOOMLEVEL>", zoomStr);
-        url.Replace("<BINGAPIKEY>", wxString(bing_api_key));
+        url.Replace("<LONLAT>", wxString::Format("%.14lf,%.14lf", lon, lat));
         url.Replace("<AZUREAPIKEY>", wxString(azure_api_key));
     }
 
     wxEasyCurl curl;
+
+    curl.AddHttpHeader("Accept: image/png");
+
     bool ok = curl.Get(url, "Obtaining aerial imagery...");
-    return ok ? wxBitmap(curl.GetDataAsImage(wxBITMAP_TYPE_JPEG)) : wxNullBitmap;
+
+    str = curl.GetDataAsString();
+    reader.Parse(str.c_str());
+
+    // curl Get failed
+    if (!ok) {
+        wxMessageBox("Static Map Error!\nFailed to download static map.");
+        return wxNullBitmap;
+    }
+
+    str = curl.GetDataAsString();
+    // returned JSON string instead of image, probably an error message
+    if (str != "") {
+        reader.Parse(str.c_str());
+        if (reader.HasMember(L"error")) {
+            if (reader[L"error"].HasMember(L"message")) {
+                if (reader[L"error"][L"message"].IsString()) {
+                    wxMessageBox(wxString::Format("Static Map Error!\n%s", reader[L"error"][L"message"].GetString()));
+                    return wxNullBitmap;
+                }
+            }
+            wxMessageBox(wxString::Format("Static Map Error!\n%s", reader[L"error"][L"code"].GetString()));
+            return wxNullBitmap;
+        }
+        wxMessageBox(wxString::Format("Static Map Error!\nNo map image."));
+        return false;
+    }
+    else {
+        return ok ? wxBitmap(curl.GetDataAsImage(wxBITMAP_TYPE_PNG)) : wxNullBitmap;
+    }
 }

--- a/src/geotools.cpp
+++ b/src/geotools.cpp
@@ -378,7 +378,7 @@ wxBitmap GeoTools::StaticMap(double lat, double lon, int zoom, MapProvider servi
             return wxNullBitmap;
         }
         wxMessageBox(wxString::Format("Static Map Error!\nNo map image."));
-        return false;
+        return wxNullBitmap;
     }
     else {
         return ok ? wxBitmap(curl.GetDataAsImage(wxBITMAP_TYPE_PNG)) : wxNullBitmap;

--- a/src/geotools.cpp
+++ b/src/geotools.cpp
@@ -279,9 +279,9 @@ bool GeoTools::GeocodeDeveloper(const wxString& address, double* lat, double* lo
         if (reader.HasMember(L"error")) {
             if (reader[L"error"].HasMember(L"code")) {
                 if (reader[L"error"][L"code"].IsString()) {
-                    wxString str = reader[L"error"][L"code"].GetString();
-                    if (str.Lower() != "") {
-                        wxMessageBox(wxString::Format("Time Zone API Error!\n%s", str));
+                    wxString error_str = reader[L"error"][L"code"].GetString();
+                    if (error_str.Lower() != "") {
+                        wxMessageBox(wxString::Format("Time Zone API Error!\n%s", error_str));
                         return false;
                     } 
                 }

--- a/src/geotools.h
+++ b/src/geotools.h
@@ -51,7 +51,7 @@ public:
         double* lat, double* lon, double* tz = 0, bool showprogress = true);
 
     enum MapProvider {
-        GOOGLE_MAPS, BING_MAPS
+        GOOGLE_MAPS, AZURE_MAPS
     };
 
     // Return a map for a given lat/lon and zoom level as a bitmap image

--- a/src/invoke.cpp
+++ b/src/invoke.cpp
@@ -3805,7 +3805,9 @@ void fcall_geocode(lk::invoke_t& cxt)
 		get_tz = cxt.arg(1).as_boolean();
 	}
 
-	double lat=NULL, lon=NULL, tz=NULL;
+	double lat = std::numeric_limits<double>::quiet_NaN();
+	double lon = std::numeric_limits<double>::quiet_NaN();
+	double tz = std::numeric_limits<double>::quiet_NaN();
 	bool ok = false;
 	cxt.result().empty_hash();
 

--- a/src/invoke.cpp
+++ b/src/invoke.cpp
@@ -3814,7 +3814,7 @@ void fcall_geocode(lk::invoke_t& cxt)
 	// use GeoTools::GeocodeGoogle for non-NREL builds and set google_api_key in private.h
  	if (get_tz) {
 		ok = GeoTools::GeocodeDeveloper(cxt.arg(0).as_string(), &lat, &lon, &tz);
-		cxt.result().hash_item("tz").assign(tz); // converts NULL to 0
+		cxt.result().hash_item("tz").assign(tz);
 	}
 	else {
 		ok = GeoTools::GeocodeDeveloper(cxt.arg(0).as_string(), &lat, &lon);

--- a/src/invoke.cpp
+++ b/src/invoke.cpp
@@ -3794,19 +3794,32 @@ static bool copy_mat(lk::invoke_t &cxt, wxString sched_name, matrix_t<double> &m
 	return true;
 }
 
-void fcall_geocode(lk::invoke_t& cxt) 
+void fcall_geocode(lk::invoke_t& cxt)
 {
 	LK_DOC("geocode",
-		"Given a street address or location name, returns latitude, longitude, and time zone. Not designed to take latitude and longitude as input. Uses the MapQuest Geocoding API via a private NREL wrapper. Returned table fields are 'lat', 'lon', 'tz', 'ok'.",
+		"Given a street address or location name, returns latitude, longitude. Returns optional time zone if get_tz is set to true. Not designed to take latitude and longitude as input. Uses the MapQuest Geocoding API via a private NREL wrapper. Returned table fields are 'lat', 'lon', 'tz', 'ok'.",
 		"(string):table");
 
-	double lat = 0, lon = 0, tz = 0;
-	// use GeoTools::GeocodeGoogle for non-NREL builds and set google_api_key in private.h
-	bool ok = GeoTools::GeocodeDeveloper(cxt.arg(0).as_string(), &lat, &lon, &tz);
+	bool get_tz = false;
+	if (cxt.arg_count() > 1) {
+		get_tz = cxt.arg(1).as_boolean();
+	}
+
+	double lat=NULL, lon=NULL, tz=NULL;
+	bool ok = false;
 	cxt.result().empty_hash();
+
+	// use GeoTools::GeocodeGoogle for non-NREL builds and set google_api_key in private.h
+ 	if (get_tz) {
+		ok = GeoTools::GeocodeDeveloper(cxt.arg(0).as_string(), &lat, &lon, &tz);
+		cxt.result().hash_item("tz").assign(tz); // converts NULL to 0
+	}
+	else {
+		ok = GeoTools::GeocodeDeveloper(cxt.arg(0).as_string(), &lat, &lon);
+	}
+	
 	cxt.result().hash_item("lat").assign(lat);
 	cxt.result().hash_item("lon").assign(lon);
-	cxt.result().hash_item("tz").assign(tz);
 	cxt.result().hash_item("ok").assign(ok ? 1.0 : 0.0);
 }
 

--- a/src/invoke.cpp
+++ b/src/invoke.cpp
@@ -3797,8 +3797,8 @@ static bool copy_mat(lk::invoke_t &cxt, wxString sched_name, matrix_t<double> &m
 void fcall_geocode(lk::invoke_t& cxt)
 {
 	LK_DOC("geocode",
-		"Given a street address or location name, returns latitude, longitude. Returns optional time zone if get_tz is set to true. Not designed to take latitude and longitude as input. Uses the MapQuest Geocoding API via a private NREL wrapper. Returned table fields are 'lat', 'lon', 'tz', 'ok'.",
-		"(string):table");
+		"Given a street address or location name, returns latitude, longitude. Returns optional time zone if get_tz is true. Not designed to take latitude and longitude as input. Uses the MapQuest Geocoding API via a private NREL wrapper. Returned table fields are 'lat', 'lon', 'tz', 'ok'.",
+		"(string:location, [boolean:get_tz]):table");
 
 	bool get_tz = false;
 	if (cxt.arg_count() > 1) {

--- a/src/main.h
+++ b/src/main.h
@@ -63,6 +63,7 @@ extern const char *sam_api_key;
 extern const char* geocode_api_key;
 extern const char* google_api_key;
 extern const char* bing_api_key;
+extern const char* azure_api_key;
 
 class wxSimplebook;
 class wxPanel;

--- a/src/main.h
+++ b/src/main.h
@@ -62,7 +62,6 @@ struct smart_ptr
 extern const char *sam_api_key;
 extern const char* geocode_api_key;
 extern const char* google_api_key;
-extern const char* bing_api_key;
 extern const char* azure_api_key;
 
 class wxSimplebook;

--- a/src/main_add.h
+++ b/src/main_add.h
@@ -379,6 +379,7 @@ extern void RegisterReportObjectTypes();
 	wxEasyCurl::SetUrlEscape("<SAMAPIKEY>", wxString(sam_api_key));
 	wxEasyCurl::SetUrlEscape("<GEOCODEAPIKEY>", wxString(geocode_api_key));
 	wxEasyCurl::SetUrlEscape("<BINGAPIKEY>", wxString(bing_api_key));
+	wxEasyCurl::SetUrlEscape("<AZUREAPIKEY>", wxString(bing_api_key));
 	wxEasyCurl::SetUrlEscape("<GOOGLEAPIKEY>", wxString(google_api_key));
 
 	wxEasyCurl::SetUrlEscape("<USEREMAIL>", wxString(user_email));

--- a/src/main_add.h
+++ b/src/main_add.h
@@ -375,11 +375,9 @@ extern void RegisterReportObjectTypes();
 
 
 	wxEasyCurl::Initialize();
-	//wxEasyCurl::SetApiKeys( GOOGLE_API_KEY, BING_API_KEY, DEVELOPER_API_KEY );
 	wxEasyCurl::SetUrlEscape("<SAMAPIKEY>", wxString(sam_api_key));
 	wxEasyCurl::SetUrlEscape("<GEOCODEAPIKEY>", wxString(geocode_api_key));
-	wxEasyCurl::SetUrlEscape("<BINGAPIKEY>", wxString(bing_api_key));
-	wxEasyCurl::SetUrlEscape("<AZUREAPIKEY>", wxString(bing_api_key));
+	wxEasyCurl::SetUrlEscape("<AZUREAPIKEY>", wxString(azure_api_key));
 	wxEasyCurl::SetUrlEscape("<GOOGLEAPIKEY>", wxString(google_api_key));
 
 	wxEasyCurl::SetUrlEscape("<USEREMAIL>", wxString(user_email));

--- a/src/private.h
+++ b/src/private.h
@@ -54,6 +54,12 @@ const char *google_api_key = "";
 // Get a Bing Maps developer key at https://www.bingmapsportal.com/
 const char *bing_api_key = "";
 
+// Azure Map APIs:
+// Used for static map underlay in 3D shade calculator (Google map can be used as an option instead)
+// Used for time zone API for geocoding
+// Get a an Azure Maps key at https://azure.microsoft.com/
+const char *azure_api_key = "";
+
 // Private NREL Developer geocoding API for NREL versions of SAM
 const char *geocode_api_key = "";
 

--- a/src/private.h
+++ b/src/private.h
@@ -49,11 +49,6 @@ const char* user_email = "";
 // Requires Google Cloud account and subscription https://cloud.google.com
 const char *google_api_key = "";
 
-// Bing Map APIs:
-// Used for static map underlay in 3D shade calculator (Google map can be used as an option instead)
-// Get a Bing Maps developer key at https://www.bingmapsportal.com/
-const char *bing_api_key = "";
-
 // Azure Map APIs:
 // Used for static map underlay in 3D shade calculator (Google map can be used as an option instead)
 // Used for time zone API for geocoding


### PR DESCRIPTION
## Pull Request Template

### Description

Migrate [deprecated Bing Maps API](https://learn.microsoft.com/en-us/bingmaps/getting-started/bing-maps-dev-center-help/getting-a-bing-maps-key) to Azure Maps API. This pull requests modifies the following functions to use the Azure API, which currently do not work because we don't have an Azure API key for SAM:
   1. Time zone API for geocode function. 
   2. Static map API for 3D shade calculator map underlay
 
Make time zone optional for geocode() function to address (1) above.

Update 3D Shade Calculator to handle failed static map API calls for image underlays to address (2).

Update LK geocode() function to add optional parameter 

This is a temporary fix. For a more permanent fix:

1. Request update to NREL Developer Geocode API to return time zone. Or, consider an offline implementation such as one of the options listed in Stack Overflow [here ](https://stackoverflow.com/questions/16086962/how-to-get-a-time-zone-from-a-location-using-latitude-and-longitude-coordinates). Note that time zones do not correlate well with latitudes as can be seen in [this map](https://www.timeanddate.com/time/map/) from timeanddate.com. 

2. See if NREL Developer API can return a static map for 3D shade calculator. If not, investigate getting a Microsoft Azure key for SAM, or finding another static map service.

See https://github.com/NREL/SAM-private/pull/129 for more discussion of next steps.

Fixes #2092

Goes with https://github.com/NREL/SAM-private/pull/129

### To Test

1. Build SAM from sam-private.
2. Create a Detailed PV / Residential case.
3. On the Location and Resource page, try to download a weather file using a street address or location name. Download should work without crashing SAM.
4. On the Shading and Layout page, click **Open 3D shade calculator**,  go to the Location tab and try clicking **Lookup address** and **Update map from coordinates**. SAM should display error messages without crashing.
5. Click File, New script and run the following LK script:
```
// return lat, lon
x = geocode("portland, or");
outln(x);

// return lat, lon, tz=0 with error message
x = geocode("portland, or", true);
outln(x);
```

An optional test is to set the value of `azure_api_key` in `SAM-private/src/private.h` to a valid Microsoft Azure API key -- this should make Steps 4 and 5 work properly without error messages.

### Checklist
- [ ] requires help revision and I added that label
- [ ] adds, removes, modifies, or deletes variables in existing compute modules
- [ ] adds a new compute module
- [ ] changes defaults
- [X] I've tagged this PR to a milestone

