### PR TITLE
Updates to scripting and reports for CPA macro functionality

### DIFF
--- a/src/casewin.cpp
+++ b/src/casewin.cpp
@@ -498,25 +498,36 @@ bool CaseWindow::RunSSCBaseCase(wxString& fn, bool silent, wxString* messages)
 
 bool CaseWindow::ExportCashflowExcel()
 {
-/*	// run base case automatically
-	if (!RunBaseCase())
-	{
-		wxMessageBox("Base case simulation did not succeed.  Please check your inputs before creating a report");
-		return;
-	}
-	*/
-	if (auto *vv= m_case->BaseCase().GetOutput("annual_energy")) {
+	if (m_case != NULL) {
+		if (m_case->GetFinancing() == "None") {
+			wxMessageBox("Case must have a financial model selected.");
+			return false;
+		}
+		else {
+			if (m_case->BaseCase().Ok()) {
+				if (auto* vv = m_case->BaseCase().GetOutput("annual_energy")) {
 #ifdef __WXMSW__
-	//	UpdateResults();
-		m_baseCaseResults->Export(EXP_CASHFLOW, EXP_SEND_EXCEL);
-		return true;
+					//	UpdateResults();
+					m_baseCaseResults->Export(EXP_CASHFLOW, EXP_SEND_EXCEL);
+					return true;
 #else
-		wxMessageBox("Excel export is only supported on Windows systems.");
-		return false;
+					wxMessageBox("Excel export is only supported on Windows systems.");
+					return false;
 #endif
+				}
+				else {
+					wxMessageBox("Base case simulation did not succeed.  Please check your inputs or run the simulation before exporting cash flow.");
+					return false;
+				}
+			}
+			else {
+				wxMessageBox("Case must be successfully simulated before exporting cashflow.");
+				return false;
+			}
+		}
 	}
 	else {
-		wxMessageBox("Base case simulation did not succeed.  Please check your inputs or run the simulation before exporting cash flow.");
+		wxMessageBox("No active case selected.");
 		return false;
 	}
 }

--- a/src/casewin.cpp
+++ b/src/casewin.cpp
@@ -496,16 +496,29 @@ bool CaseWindow::RunSSCBaseCase(wxString& fn, bool silent, wxString* messages)
 }
 
 
-void CaseWindow::ExportCashflowExcel()
+bool CaseWindow::ExportCashflowExcel()
 {
-	// run base case automatically
+/*	// run base case automatically
 	if (!RunBaseCase())
 	{
 		wxMessageBox("Base case simulation did not succeed.  Please check your inputs before creating a report");
 		return;
 	}
-	UpdateResults();
-	m_baseCaseResults->Export(EXP_CASHFLOW, EXP_SEND_EXCEL);
+	*/
+	if (auto *vv= m_case->BaseCase().GetOutput("annual_energy")) {
+#ifdef __WXMSW__
+	//	UpdateResults();
+		m_baseCaseResults->Export(EXP_CASHFLOW, EXP_SEND_EXCEL);
+		return true;
+#else
+		wxMessageBox("Excel export is only supported on Windows systems.");
+		return false;
+#endif
+	}
+	else {
+		wxMessageBox("Base case simulation did not succeed.  Please check your inputs or run the simulation before exporting cash flow.");
+		return false;
+	}
 }
 
 

--- a/src/casewin.cpp
+++ b/src/casewin.cpp
@@ -499,31 +499,34 @@ bool CaseWindow::RunSSCBaseCase(wxString& fn, bool silent, wxString* messages)
 bool CaseWindow::ExportCashflowExcel()
 {
 	if (m_case != NULL) {
-		if (m_case->GetFinancing() == "None") {
-			wxMessageBox("Case must have a financial model selected.");
-			return false;
+
+		// if no outputs run a simulation. this approach could result in exported cash flow not matching current inputs if user modifies inputs without running a simulation before exporting
+		if (m_case->BaseCase().Outputs().size() == 0) {
+			RunBaseCase();
+		}
+
+		// all cash flow models have cf_om_fixed_expense output except standalone battery
+		bool is_cf_model;
+		if (auto* vv = m_case->BaseCase().GetOutput("cf_om_fixed_expense"))
+			is_cf_model = true;
+		else if (auto* vv1 = m_case->BaseCase().GetOutput("cf_om_fixed1_expense")) // standalone battery
+			is_cf_model = true;
+		else
+			is_cf_model = false;
+
+		if ( is_cf_model ) {
+#ifdef __WXMSW__
+				//	UpdateResults();
+				m_baseCaseResults->Export(EXP_CASHFLOW, EXP_SEND_EXCEL);
+				return true;
+#else
+				wxMessageBox("Excel export is only supported on Windows systems.");
+				return false;
+#endif
 		}
 		else {
-			if (m_case->BaseCase().Ok()) {
-				if (auto* vv = m_case->BaseCase().GetOutput("annual_energy")) {
-#ifdef __WXMSW__
-					//	UpdateResults();
-					m_baseCaseResults->Export(EXP_CASHFLOW, EXP_SEND_EXCEL);
-					return true;
-#else
-					wxMessageBox("Excel export is only supported on Windows systems.");
-					return false;
-#endif
-				}
-				else {
-					wxMessageBox("Base case simulation did not succeed.  Please check your inputs or run the simulation before exporting cash flow.");
-					return false;
-				}
-			}
-			else {
-				wxMessageBox("Case must be successfully simulated before exporting cashflow.");
-				return false;
-			}
+			wxMessageBox("No cash flow to export. Export cash flow requires a cash flow-based financial model.");
+			return false;
 		}
 	}
 	else {

--- a/src/casewin.cpp
+++ b/src/casewin.cpp
@@ -496,6 +496,19 @@ bool CaseWindow::RunSSCBaseCase(wxString& fn, bool silent, wxString* messages)
 }
 
 
+void CaseWindow::ExportCashflowExcel()
+{
+	// run base case automatically
+	if (!RunBaseCase())
+	{
+		wxMessageBox("Base case simulation did not succeed.  Please check your inputs before creating a report");
+		return;
+	}
+	UpdateResults();
+	m_baseCaseResults->Export(EXP_CASHFLOW, EXP_SEND_EXCEL);
+}
+
+
 void CaseWindow::UpdateResults()
 {
 	m_baseCaseResults->Setup( &m_case->BaseCase() );

--- a/src/casewin.h
+++ b/src/casewin.h
@@ -100,7 +100,7 @@ public:
 	bool RunBaseCase( bool silent = false, wxString *messages = 0 );
 	void UpdateResults();
 
-	void ExportCashflowExcel();
+	bool ExportCashflowExcel();
 
 	bool RunSSCBaseCase(wxString& fn, bool silent = false, wxString* messages = 0);
 

--- a/src/casewin.h
+++ b/src/casewin.h
@@ -100,6 +100,8 @@ public:
 	bool RunBaseCase( bool silent = false, wxString *messages = 0 );
 	void UpdateResults();
 
+	void ExportCashflowExcel();
+
 	bool RunSSCBaseCase(wxString& fn, bool silent = false, wxString* messages = 0);
 
 	bool GenerateReport( 

--- a/src/macro.cpp
+++ b/src/macro.cpp
@@ -32,6 +32,7 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 
 #include "macro.h"
+#include "invoke.h"
 
 class macro_vm : public lk::vm
 {

--- a/src/reports.cpp
+++ b/src/reports.cpp
@@ -2255,11 +2255,16 @@ void SamReportScriptObject::Render( wxPageOutputDevice &dv )
 		env.register_funcs( lk::stdlib_math() );
 		env.register_funcs( lk::stdlib_wxui() );
 
-		wxStopWatch sw;
-		lk::eval e( tree, &env );
-		if ( !e.run() )
-			for (size_t i=0;i<e.error_count();i++)
-				errors += e.get_error(i) + "\n";
+		try {
+			wxStopWatch sw;
+			lk::eval e(tree, &env);
+			if (!e.run())
+				for (size_t i = 0; i < e.error_count(); i++)
+					errors += e.get_error(i) + "\n";
+		}
+		catch (std::exception e) {
+			wxMessageBox(e.what());
+		}
 	}
 			
 	int i=0;
@@ -2559,7 +2564,7 @@ void SamReportScriptObject::RenderTable( const matrix_t<wxString> &tab )
 		float xpos = tab_x;
 		for (int c=0;c<(int)tab.ncols();c++)
 		{
-			int align = (r==0) ? m_headerAlign : m_cellAlign;
+			int align = (r<m_headerLines) ? m_headerAlign : m_cellAlign;
 			switch( align )
 			{
 			case wxLEFT:
@@ -2602,11 +2607,11 @@ void SamReportScriptObject::RenderTable( const matrix_t<wxString> &tab )
 	}
 	
 	m_curDevice->Color( *wxBLACK );
-	if (m_headerLine && row_heights.size() > 0)
-		m_curDevice->Line( tab_x, tab_y+row_heights[0], 
-			tab_x+tab_width, tab_y+row_heights[0] );
+	if (m_headerLine && row_heights.size() > 0 )
+		m_curDevice->Line( tab_x, tab_y+m_headerLines*row_heights[0], 
+			tab_x+tab_width, tab_y+ m_headerLines * row_heights[0] );
     float ypos_total_lines = tab_y+row_heights[0];
-    for (int r = 1; r < (int)tab.nrows(); r++) {
+    for (int r = m_headerLines - 1; r < (int)tab.nrows(); r++) {
         ypos_total_lines += row_heights[r];
         for (int b = 0; b < m_totalLines.size(); b++) {
             if (r == m_totalLines[b] && r != (int)tab.nrows() - 1) {

--- a/src/results.h
+++ b/src/results.h
@@ -191,6 +191,8 @@ public:
 	TabularBrowser *GetTabularBrowser() { return m_tables; }
 	wxString GetCurrentContext() const;
 	
+	void Export(int data, int mechanism);
+
 private:	
 	Simulation *m_sim = nullptr;
 
@@ -227,7 +229,6 @@ private:
 
 	void AddDataSet( wxDVTimeSeriesDataSet *ds, const wxString &group = wxEmptyString, bool update_ui = true );
 	void RemoveAllDataSets();
-	void Export(int data, int mechanism);
 	void GetExportData(int data, matrix_t<wxString> &table);
 	void ExportEqnExcel();
 

--- a/src/script.cpp
+++ b/src/script.cpp
@@ -592,7 +592,7 @@ void fcall_show_page(lk::invoke_t &cxt)
 
 void fcall_export_cashflow_excel(lk::invoke_t& cxt)
 {
-	LK_DOC("export_cashflow_excel", "Exports the cashflow for the active case to Excel (Windows only)", "():boolean");
+	LK_DOC("export_cashflow_excel", "Exports the current cash flow to Excel from the active case (Windows only). Runs a simulation before exporting only if the case has no results.", "():boolean");
 	Case* active_case = CurrentCase();
 	if (CaseWindow* case_window = SamApp::Window()->GetCaseWindow(active_case)) {
 		cxt.result().assign(case_window->ExportCashflowExcel() ? 1.0 : 0.0);

--- a/src/script.cpp
+++ b/src/script.cpp
@@ -590,6 +590,16 @@ void fcall_show_page(lk::invoke_t &cxt)
 	else cxt.error("no active case");
 }
 
+void fcall_export_cashflow_excel(lk::invoke_t& cxt)
+{
+	LK_DOC("export_cashflow_excel", "Exports the cashflow for the active case to Excel (Windows only)", "( string:page name ):boolean");
+	Case* active_case = CurrentCase();
+	if (CaseWindow* case_window = SamApp::Window()->GetCaseWindow(active_case)) {
+		case_window->ExportCashflowExcel();
+	}
+	else cxt.error("no active case");
+}
+
 void fcall_widgetpos( lk::invoke_t &cxt )
 {
 	LK_DOC("widgetpos", "Get geometry in pixels in toplevel coordinates of the widget associated with the specified variable.", "(string:name):array" );
@@ -659,6 +669,7 @@ lk::fcall_t *sam_functions() {
 		fcall_simulate,
         fcall_simulate_ssc_tests,
 		fcall_show_page,
+		fcall_export_cashflow_excel,
 		fcall_widgetpos,
 		fcall_focusto,
 		fcall_configuration,

--- a/src/script.cpp
+++ b/src/script.cpp
@@ -595,24 +595,7 @@ void fcall_export_cashflow_excel(lk::invoke_t& cxt)
 	LK_DOC("export_cashflow_excel", "Exports the cashflow for the active case to Excel (Windows only)", "():boolean");
 	Case* active_case = CurrentCase();
 	if (CaseWindow* case_window = SamApp::Window()->GetCaseWindow(active_case)) {
-		if (auto* c = case_window->GetCase()) {
-			if (c->GetFinancing() == "None") {
-				cxt.error("case must have a financial model");
-				cxt.result().assign(0.0);
-			}
-			else {
-				if (c->BaseCase().Ok())
-					cxt.result().assign(case_window->ExportCashflowExcel() ? 1.0 : 0.0);
-				else {
-					cxt.error("case must be successfully simulated before exporting cashflow");
-					cxt.result().assign(0.0);
-				}
-			}
-		}
-		else {
-			cxt.error("no active case");
-			cxt.result().assign(0.0);
-		}
+		cxt.result().assign(case_window->ExportCashflowExcel() ? 1.0 : 0.0);
 	}
 	else {
 		cxt.error("no active case window");


### PR DESCRIPTION
Changes

casewin - add ExportCasflowExcel
reports - fix multiple table header lines
script - add fcall_export_cashflow_excel
macro - include invoke.h
results - move Export from private to public


Easiest way to test is to 
1. copy the deploy/runtime/macros/Community Solar/Community Power Accelerator.lk macro over to this branch (but do not commit) 
2. copy the deploy/runtime/quickstart/CPA-CommunitySolar.samreport report template (but  do not commit) 
3. create a PVWatts/Community solar case
4. run the Community Power Accelerator macro
5. Check that the cash flow exports and the pdf report has a 2-line column header
