### PR TITLE
New curtailment callback for marine doesn't apply to merchant plant. …

### DIFF
--- a/deploy/runtime/ui/Financial Analysis Host Developer Parameters.json
+++ b/deploy/runtime/ui/Financial Analysis Host Developer Parameters.json
@@ -864,8 +864,7 @@
         "  property('analysis_period_warning','caption',txt);",
         "  refresh();\r",
         "  change_tax_array_length();\r",
-        "  change_depreciation_length();\r",
-        "  change_curtailment_price_length();",
+        "  change_depreciation_length();",
         "};",
         ""
     ]

--- a/deploy/runtime/ui/Financial Analysis Parameters.json
+++ b/deploy/runtime/ui/Financial Analysis Parameters.json
@@ -632,7 +632,9 @@
         "  txt = analysis_period_message();",
         "  property('analysis_period_warning','caption',txt);\r",
         "  change_tax_array_length();\r",
-        "  change_curtailment_price_length();\r",
+        "  if  ( financing() != 'Merchant Plant') {\r",
+        "\tchange_curtailment_price_length();\r",
+        "  }\r",
         "  change_depreciation_length();",
         "};",
         ""

--- a/deploy/runtime/ui/Financial Analysis Parameters.json
+++ b/deploy/runtime/ui/Financial Analysis Parameters.json
@@ -632,10 +632,12 @@
         "  txt = analysis_period_message();",
         "  property('analysis_period_warning','caption',txt);\r",
         "  change_tax_array_length();\r",
-        "  if  ( financing() != 'Merchant Plant') {\r",
+        "  if  ( financing() == 'Single Owner') {\r",
         "\tchange_curtailment_price_length();\r",
         "  }\r",
-        "  change_depreciation_length();",
+        "  if (financing() != 'Residential' && financing() != 'LCOE Calculator' && financing() != 'None') {\r",
+        "\tchange_depreciation_length();\r",
+        "  }",
         "};",
         ""
     ]


### PR DESCRIPTION
…Add logic to the callback to cover this case

## Pull Request Template

### Description

Merchant plant doesn't have the curtailment widget (and I'm not sure it needs one given cleared capacity inputs). Cover this case in the analysis period callback to avoid callback errors.

Fixes # https://github.com/NREL/SAM/issues/2138

### Corresponding branches and PRs:

Develop for other branches

### Unit Test Impact:

No expected test impact (our UI tests aren't this sophisticated, for better or worse)

### Checklist
- [ ] requires help revision and I added that label
- [ ] adds, removes, modifies, or deletes variables in existing compute modules
- [ ] adds a new compute module
- [ ] changes defaults
- [x] I've tagged this PR to a milestone


