### PR TITLE
Set Pxx value to unsigned, limit to 1-99

### DIFF
--- a/src/pvuncertainty.cpp
+++ b/src/pvuncertainty.cpp
@@ -150,7 +150,8 @@ PVUncertaintyForm::PVUncertaintyForm( wxWindow *parent, Case *cc )
 
     wxStaticBoxSizer *sizer_changePvalue = new wxStaticBoxSizer( wxHORIZONTAL, this, "Update P value" );
     label = new wxStaticText( this, wxID_ANY, "Custom Px:" );
-    m_puser = new wxNumericCtrl( this, wxID_ANY, 90, wxNUMERIC_REAL );
+    m_puser = new wxNumericCtrl( this, wxID_ANY, 90, wxNUMERIC_UNSIGNED );
+    m_puser->SetRange(1, 99);
     sizer_changePvalue->AddSpacer( 20 );
     sizer_changePvalue->Add( label , 0, wxLEFT|wxRIGHT|wxALIGN_CENTER_VERTICAL, 0 );
     sizer_changePvalue->Add( m_puser, 0, wxALL|wxALIGN_CENTER_VERTICAL, 3 );

--- a/src/pvuncertainty.cpp
+++ b/src/pvuncertainty.cpp
@@ -150,6 +150,10 @@ PVUncertaintyForm::PVUncertaintyForm( wxWindow *parent, Case *cc )
 
     wxStaticBoxSizer *sizer_changePvalue = new wxStaticBoxSizer( wxHORIZONTAL, this, "Update P value" );
     label = new wxStaticText( this, wxID_ANY, "Custom Px:" );
+    int pValue = static_cast<int>(m_data.pValue);
+    if (pValue < 1) pValue = 1;
+    else if (pValue > 99) pValue = 99;
+    m_data.pValue = pValue;
     m_puser = new wxNumericCtrl( this, wxID_ANY, 90, wxNUMERIC_UNSIGNED );
     m_puser->SetRange(1, 99);
     sizer_changePvalue->AddSpacer( 20 );


### PR DESCRIPTION
## Pull Request Template

### Description

-Update PXX input on PV Uncertainty form to be unsigned, limited to 1-99



Fixes #1970

### Corresponding branches and PRs:

develop everywhere else



### Unit Test Impact:

[ new tests written? ]
NO
[ expected changes in unit tests or speed of tests? ]
None
[ expected changes in test_results files? ]
None
### Checklist
- [ ] requires help revision and I added that label
- [ ] adds, removes, modifies, or deletes variables in existing compute modules
- [ ] adds a new compute module
- [ ] changes defaults
- [ ] I've tagged this PR to a milestone

### Reminders- this section can be deleted
[Checking for PySAM Incompatible API Changes]
(https://github.com/NREL/SAM/wiki/PySAM-Incompatible-API-Changes-&-Regenerating-PySAM-Files).

[When do the PySAM files need to be regenerated?]
(https://github.com/NREL/SAM/wiki/PySAM-Incompatible-API-Changes-&-Regenerating-PySAM-Files#when-do-the-pysam-files-need-to-be-regenerated-via-export_config)
