### PR TITLE
Change trough IAM/solar position table widgets

### DIFF
--- a/deploy/runtime/ui/Physical Trough Collector Type 1.json
+++ b/deploy/runtime/ui/Physical Trough Collector Type 1.json
@@ -163,7 +163,7 @@
                 }
             }
         },
-        "DataArray": {
+        "DataArrayTable": {
             "Visible": 1.0,
             "ObjectProperties": {
                 "Name": {
@@ -172,37 +172,97 @@
                 },
                 "X": {
                     "Type": 3.0,
-                    "Integer": 600.0
+                    "Integer": 57.0
                 },
                 "Y": {
                     "Type": 3.0,
-                    "Integer": 354.0
+                    "Integer": 423.0
                 },
                 "Width": {
                     "Type": 3.0,
-                    "Integer": 90.0
+                    "Integer": 187.0
                 },
                 "Height": {
                     "Type": 3.0,
-                    "Integer": 28.0
+                    "Integer": 279.0
                 },
                 "Tool Tip": {
                     "Type": 5.0,
                     "String": ""
                 },
-                "Mode": {
-                    "Type": 3.0,
-                    "Integer": 2.0
+                "PasteAppendRows": {
+                    "Type": 2.0,
+                    "Boolean": 0.0
                 },
-                "Label": {
-                    "Type": 5.0,
-                    "String": "IAM Coefficients"
+                "PasteAppendCols": {
+                    "Type": 2.0,
+                    "Boolean": 0.0
                 },
-                "Description": {
+                "ShowButtons": {
+                    "Type": 2.0,
+                    "Boolean": 1.0
+                },
+                "ShowRows": {
+                    "Type": 2.0,
+                    "Boolean": 1.0
+                },
+                "ShowRowLabels": {
+                    "Type": 2.0,
+                    "Boolean": 0.0
+                },
+                "RowLabels": {
                     "Type": 5.0,
                     "String": ""
                 },
-                "TabOrder": {
+                "ShadeR0C0": {
+                    "Type": 2.0,
+                    "Boolean": 0.0
+                },
+                "VerticalLabel": {
+                    "Type": 5.0,
+                    "String": ""
+                },
+                "HorizontalLabel": {
+                    "Type": 5.0,
+                    "String": ""
+                },
+                "ShadeC0": {
+                    "Type": 2.0,
+                    "Boolean": 0.0
+                },
+                "ShowCols": {
+                    "Type": 2.0,
+                    "Boolean": 0.0
+                },
+                "ShowColLabels": {
+                    "Type": 2.0,
+                    "Boolean": 1.0
+                },
+                "ColLabels": {
+                    "Type": 5.0,
+                    "String": "IAM Coefficients"
+                },
+                "NumRowsLabel": {
+                    "Type": 5.0,
+                    "String": "Rows:"
+                },
+                "NumColsLabel": {
+                    "Type": 5.0,
+                    "String": "Cols:"
+                },
+                "Layout": {
+                    "Type": 3.0,
+                    "Integer": 1.0
+                },
+                "Choices": {
+                    "Type": 5.0,
+                    "String": "Choice1,Choice2"
+                },
+                "HideColumn": {
+                    "Type": 3.0,
+                    "Integer": -1.0
+                },
+                "ShowColumn": {
                     "Type": 3.0,
                     "Integer": -1.0
                 }
@@ -217,7 +277,7 @@
                 },
                 "X": {
                     "Type": 3.0,
-                    "Integer": 15.0
+                    "Integer": 9.0
                 },
                 "Y": {
                     "Type": 3.0,
@@ -225,7 +285,7 @@
                 },
                 "Width": {
                     "Type": 3.0,
-                    "Integer": 769.0
+                    "Integer": 766.0
                 },
                 "Height": {
                     "Type": 3.0,
@@ -1683,7 +1743,7 @@
                 },
                 "Height": {
                     "Type": 3.0,
-                    "Integer": 372.0
+                    "Integer": 375.0
                 },
                 "Tool Tip": {
                     "Type": 5.0,
@@ -1721,7 +1781,7 @@
             "Units": " ",
             "Group": "Physical Trough Collector Type 1",
             "IndexLabels": "",
-            "Flags": 2.0,
+            "Flags": 3.0,
             "DefaultValue": [
                 1.0,
                 0.0506,
@@ -2096,8 +2156,8 @@
         "};\r",
         "\r",
         "on_change{\"DISP_opt_model_1\"}=define(){\r",
-        "\tenable(\"OpticalTable_1\", ${DISP_opt_model_1} != 2);\r",
-        "\tenable(\"IAMs_1\", ${DISP_opt_model_1} == 2);\r",
+        "\tshow(\"OpticalTable_1\", ${DISP_opt_model_1} != 2);\r",
+        "\tshow(\"IAMs_1\", ${DISP_opt_model_1} == 2);\r",
         "};",
         ""
     ]

--- a/deploy/runtime/ui/Physical Trough Collector Type 1.json
+++ b/deploy/runtime/ui/Physical Trough Collector Type 1.json
@@ -1787,7 +1787,7 @@
                 0.0506,
                 -0.1763
             ],
-            "UIObject": "DataArray",
+            "UIObject": "DataArrayTable",
             "sscVariableName": "",
             "sscVariableValue": ""
         },

--- a/deploy/runtime/ui/Physical Trough Collector Type 1.json
+++ b/deploy/runtime/ui/Physical Trough Collector Type 1.json
@@ -184,7 +184,7 @@
                 },
                 "Height": {
                     "Type": 3.0,
-                    "Integer": 279.0
+                    "Integer": 183.0
                 },
                 "Tool Tip": {
                     "Type": 5.0,
@@ -281,7 +281,7 @@
                 },
                 "Y": {
                     "Type": 3.0,
-                    "Integer": 423.0
+                    "Integer": 426.0
                 },
                 "Width": {
                     "Type": 3.0,
@@ -289,7 +289,7 @@
                 },
                 "Height": {
                     "Type": 3.0,
-                    "Integer": 273.0
+                    "Integer": 270.0
                 },
                 "Tool Tip": {
                     "Type": 5.0,

--- a/deploy/runtime/ui/Physical Trough Collector Type 2.json
+++ b/deploy/runtime/ui/Physical Trough Collector Type 2.json
@@ -1787,7 +1787,7 @@
                 0.0506,
                 -0.1763
             ],
-            "UIObject": "DataArray",
+            "UIObject": "DataArrayTable",
             "sscVariableName": "",
             "sscVariableValue": ""
         },

--- a/deploy/runtime/ui/Physical Trough Collector Type 2.json
+++ b/deploy/runtime/ui/Physical Trough Collector Type 2.json
@@ -184,7 +184,7 @@
                 },
                 "Height": {
                     "Type": 3.0,
-                    "Integer": 279.0
+                    "Integer": 183.0
                 },
                 "Tool Tip": {
                     "Type": 5.0,
@@ -281,7 +281,7 @@
                 },
                 "Y": {
                     "Type": 3.0,
-                    "Integer": 432.0
+                    "Integer": 435.0
                 },
                 "Width": {
                     "Type": 3.0,
@@ -289,7 +289,7 @@
                 },
                 "Height": {
                     "Type": 3.0,
-                    "Integer": 273.0
+                    "Integer": 270.0
                 },
                 "Tool Tip": {
                     "Type": 5.0,

--- a/deploy/runtime/ui/Physical Trough Collector Type 2.json
+++ b/deploy/runtime/ui/Physical Trough Collector Type 2.json
@@ -1,7 +1,7 @@
 {
     "Name": "Physical Trough Collector Type 2",
-    "Width": 805.0,
-    "Height": 723.0,
+    "Width": 809.0,
+    "Height": 727.0,
     "FormObjects": {
         "RadioChoice": {
             "Visible": 1.0,
@@ -163,7 +163,7 @@
                 }
             }
         },
-        "DataArray": {
+        "DataArrayTable": {
             "Visible": 1.0,
             "ObjectProperties": {
                 "Name": {
@@ -172,37 +172,97 @@
                 },
                 "X": {
                     "Type": 3.0,
-                    "Integer": 603.0
+                    "Integer": 57.0
                 },
                 "Y": {
                     "Type": 3.0,
-                    "Integer": 363.0
+                    "Integer": 432.0
                 },
                 "Width": {
                     "Type": 3.0,
-                    "Integer": 90.0
+                    "Integer": 187.0
                 },
                 "Height": {
                     "Type": 3.0,
-                    "Integer": 28.0
+                    "Integer": 279.0
                 },
                 "Tool Tip": {
                     "Type": 5.0,
                     "String": ""
                 },
-                "Mode": {
-                    "Type": 3.0,
-                    "Integer": 2.0
+                "PasteAppendRows": {
+                    "Type": 2.0,
+                    "Boolean": 0.0
                 },
-                "Label": {
-                    "Type": 5.0,
-                    "String": "IAM Coefficients"
+                "PasteAppendCols": {
+                    "Type": 2.0,
+                    "Boolean": 0.0
                 },
-                "Description": {
+                "ShowButtons": {
+                    "Type": 2.0,
+                    "Boolean": 1.0
+                },
+                "ShowRows": {
+                    "Type": 2.0,
+                    "Boolean": 1.0
+                },
+                "ShowRowLabels": {
+                    "Type": 2.0,
+                    "Boolean": 0.0
+                },
+                "RowLabels": {
                     "Type": 5.0,
                     "String": ""
                 },
-                "TabOrder": {
+                "ShadeR0C0": {
+                    "Type": 2.0,
+                    "Boolean": 0.0
+                },
+                "VerticalLabel": {
+                    "Type": 5.0,
+                    "String": ""
+                },
+                "HorizontalLabel": {
+                    "Type": 5.0,
+                    "String": ""
+                },
+                "ShadeC0": {
+                    "Type": 2.0,
+                    "Boolean": 0.0
+                },
+                "ShowCols": {
+                    "Type": 2.0,
+                    "Boolean": 0.0
+                },
+                "ShowColLabels": {
+                    "Type": 2.0,
+                    "Boolean": 1.0
+                },
+                "ColLabels": {
+                    "Type": 5.0,
+                    "String": "IAM Coefficients"
+                },
+                "NumRowsLabel": {
+                    "Type": 5.0,
+                    "String": "Rows:"
+                },
+                "NumColsLabel": {
+                    "Type": 5.0,
+                    "String": "Cols:"
+                },
+                "Layout": {
+                    "Type": 3.0,
+                    "Integer": 1.0
+                },
+                "Choices": {
+                    "Type": 5.0,
+                    "String": "Choice1,Choice2"
+                },
+                "HideColumn": {
+                    "Type": 3.0,
+                    "Integer": -1.0
+                },
+                "ShowColumn": {
                     "Type": 3.0,
                     "Integer": -1.0
                 }
@@ -1683,7 +1743,7 @@
                 },
                 "Height": {
                     "Type": 3.0,
-                    "Integer": 372.0
+                    "Integer": 375.0
                 },
                 "Tool Tip": {
                     "Type": 5.0,
@@ -1721,7 +1781,7 @@
             "Units": " ",
             "Group": "Physical Trough Collector Type 2",
             "IndexLabels": "",
-            "Flags": 2.0,
+            "Flags": 3.0,
             "DefaultValue": [
                 1.0,
                 0.0506,
@@ -2085,8 +2145,8 @@
         "};",
         "\r",
         "on_change{\"DISP_opt_model_2\"}=define(){\r",
-        "\tenable(\"OpticalTable_2\", ${DISP_opt_model_2} != 2);\r",
-        "\tenable(\"IAMs_2\", ${DISP_opt_model_2} == 2);\r",
+        "\tshow(\"OpticalTable_2\", ${DISP_opt_model_2} != 2);\r",
+        "\tshow(\"IAMs_2\", ${DISP_opt_model_2} == 2);\r",
         "};\r",
         ""
     ]

--- a/deploy/runtime/ui/Physical Trough Collector Type 3.json
+++ b/deploy/runtime/ui/Physical Trough Collector Type 3.json
@@ -1787,7 +1787,7 @@
                 0.0506,
                 -0.1763
             ],
-            "UIObject": "DataArray",
+            "UIObject": "DataArrayTable",
             "sscVariableName": "",
             "sscVariableValue": ""
         },

--- a/deploy/runtime/ui/Physical Trough Collector Type 3.json
+++ b/deploy/runtime/ui/Physical Trough Collector Type 3.json
@@ -184,7 +184,7 @@
                 },
                 "Height": {
                     "Type": 3.0,
-                    "Integer": 279.0
+                    "Integer": 183.0
                 },
                 "Tool Tip": {
                     "Type": 5.0,
@@ -281,7 +281,7 @@
                 },
                 "Y": {
                     "Type": 3.0,
-                    "Integer": 432.0
+                    "Integer": 435.0
                 },
                 "Width": {
                     "Type": 3.0,
@@ -289,7 +289,7 @@
                 },
                 "Height": {
                     "Type": 3.0,
-                    "Integer": 273.0
+                    "Integer": 270.0
                 },
                 "Tool Tip": {
                     "Type": 5.0,

--- a/deploy/runtime/ui/Physical Trough Collector Type 3.json
+++ b/deploy/runtime/ui/Physical Trough Collector Type 3.json
@@ -1,7 +1,7 @@
 {
     "Name": "Physical Trough Collector Type 3",
-    "Width": 805.0,
-    "Height": 719.0,
+    "Width": 806.0,
+    "Height": 726.0,
     "FormObjects": {
         "RadioChoice": {
             "Visible": 1.0,
@@ -163,7 +163,7 @@
                 }
             }
         },
-        "DataArray": {
+        "DataArrayTable": {
             "Visible": 1.0,
             "ObjectProperties": {
                 "Name": {
@@ -172,37 +172,97 @@
                 },
                 "X": {
                     "Type": 3.0,
-                    "Integer": 603.0
+                    "Integer": 57.0
                 },
                 "Y": {
                     "Type": 3.0,
-                    "Integer": 363.0
+                    "Integer": 432.0
                 },
                 "Width": {
                     "Type": 3.0,
-                    "Integer": 90.0
+                    "Integer": 187.0
                 },
                 "Height": {
                     "Type": 3.0,
-                    "Integer": 28.0
+                    "Integer": 279.0
                 },
                 "Tool Tip": {
                     "Type": 5.0,
                     "String": ""
                 },
-                "Mode": {
-                    "Type": 3.0,
-                    "Integer": 2.0
+                "PasteAppendRows": {
+                    "Type": 2.0,
+                    "Boolean": 0.0
                 },
-                "Label": {
-                    "Type": 5.0,
-                    "String": "IAM Coefficients"
+                "PasteAppendCols": {
+                    "Type": 2.0,
+                    "Boolean": 0.0
                 },
-                "Description": {
+                "ShowButtons": {
+                    "Type": 2.0,
+                    "Boolean": 1.0
+                },
+                "ShowRows": {
+                    "Type": 2.0,
+                    "Boolean": 1.0
+                },
+                "ShowRowLabels": {
+                    "Type": 2.0,
+                    "Boolean": 0.0
+                },
+                "RowLabels": {
                     "Type": 5.0,
                     "String": ""
                 },
-                "TabOrder": {
+                "ShadeR0C0": {
+                    "Type": 2.0,
+                    "Boolean": 0.0
+                },
+                "VerticalLabel": {
+                    "Type": 5.0,
+                    "String": ""
+                },
+                "HorizontalLabel": {
+                    "Type": 5.0,
+                    "String": ""
+                },
+                "ShadeC0": {
+                    "Type": 2.0,
+                    "Boolean": 0.0
+                },
+                "ShowCols": {
+                    "Type": 2.0,
+                    "Boolean": 0.0
+                },
+                "ShowColLabels": {
+                    "Type": 2.0,
+                    "Boolean": 1.0
+                },
+                "ColLabels": {
+                    "Type": 5.0,
+                    "String": "IAM Coefficients"
+                },
+                "NumRowsLabel": {
+                    "Type": 5.0,
+                    "String": "Rows:"
+                },
+                "NumColsLabel": {
+                    "Type": 5.0,
+                    "String": "Cols:"
+                },
+                "Layout": {
+                    "Type": 3.0,
+                    "Integer": 1.0
+                },
+                "Choices": {
+                    "Type": 5.0,
+                    "String": "Choice1,Choice2"
+                },
+                "HideColumn": {
+                    "Type": 3.0,
+                    "Integer": -1.0
+                },
+                "ShowColumn": {
                     "Type": 3.0,
                     "Integer": -1.0
                 }
@@ -1683,7 +1743,7 @@
                 },
                 "Height": {
                     "Type": 3.0,
-                    "Integer": 372.0
+                    "Integer": 378.0
                 },
                 "Tool Tip": {
                     "Type": 5.0,
@@ -1721,7 +1781,7 @@
             "Units": " ",
             "Group": "Physical Trough Collector Type 3",
             "IndexLabels": "",
-            "Flags": 2.0,
+            "Flags": 3.0,
             "DefaultValue": [
                 1.0,
                 0.0506,
@@ -2085,8 +2145,8 @@
         "};",
         "\r",
         "on_change{\"DISP_opt_model_3\"}=define(){\r",
-        "\tenable(\"OpticalTable_3\", ${DISP_opt_model_3} != 2);\r",
-        "\tenable(\"IAMs_3\", ${DISP_opt_model_3} == 2);\r",
+        "\tshow(\"OpticalTable_3\", ${DISP_opt_model_3} != 2);\r",
+        "\tshow(\"IAMs_3\", ${DISP_opt_model_3} == 2);\r",
         "};"
     ]
 }

--- a/deploy/runtime/ui/Physical Trough Collector Type 4.json
+++ b/deploy/runtime/ui/Physical Trough Collector Type 4.json
@@ -1787,7 +1787,7 @@
                 0.0506,
                 -0.1763
             ],
-            "UIObject": "DataArray",
+            "UIObject": "DataArrayTable",
             "sscVariableName": "",
             "sscVariableValue": ""
         },

--- a/deploy/runtime/ui/Physical Trough Collector Type 4.json
+++ b/deploy/runtime/ui/Physical Trough Collector Type 4.json
@@ -184,7 +184,7 @@
                 },
                 "Height": {
                     "Type": 3.0,
-                    "Integer": 279.0
+                    "Integer": 183.0
                 },
                 "Tool Tip": {
                     "Type": 5.0,
@@ -281,7 +281,7 @@
                 },
                 "Y": {
                     "Type": 3.0,
-                    "Integer": 432.0
+                    "Integer": 435.0
                 },
                 "Width": {
                     "Type": 3.0,
@@ -289,7 +289,7 @@
                 },
                 "Height": {
                     "Type": 3.0,
-                    "Integer": 273.0
+                    "Integer": 270.0
                 },
                 "Tool Tip": {
                     "Type": 5.0,

--- a/deploy/runtime/ui/Physical Trough Collector Type 4.json
+++ b/deploy/runtime/ui/Physical Trough Collector Type 4.json
@@ -1779,7 +1779,7 @@
             "Type": 2.0,
             "Label": "Incidence angle modifier coefficients",
             "Units": " ",
-            "Group": "Physical Trough Collector Type 3",
+            "Group": "Physical Trough Collector Type 4",
             "IndexLabels": "",
             "Flags": 3.0,
             "DefaultValue": [

--- a/deploy/runtime/ui/Physical Trough Collector Type 4.json
+++ b/deploy/runtime/ui/Physical Trough Collector Type 4.json
@@ -1,7 +1,7 @@
 {
     "Name": "Physical Trough Collector Type 4",
-    "Width": 804.0,
-    "Height": 723.0,
+    "Width": 805.0,
+    "Height": 727.0,
     "FormObjects": {
         "RadioChoice": {
             "Visible": 1.0,
@@ -163,7 +163,7 @@
                 }
             }
         },
-        "DataArray": {
+        "DataArrayTable": {
             "Visible": 1.0,
             "ObjectProperties": {
                 "Name": {
@@ -172,37 +172,97 @@
                 },
                 "X": {
                     "Type": 3.0,
-                    "Integer": 603.0
+                    "Integer": 57.0
                 },
                 "Y": {
                     "Type": 3.0,
-                    "Integer": 363.0
+                    "Integer": 432.0
                 },
                 "Width": {
                     "Type": 3.0,
-                    "Integer": 90.0
+                    "Integer": 187.0
                 },
                 "Height": {
                     "Type": 3.0,
-                    "Integer": 28.0
+                    "Integer": 279.0
                 },
                 "Tool Tip": {
                     "Type": 5.0,
                     "String": ""
                 },
-                "Mode": {
-                    "Type": 3.0,
-                    "Integer": 2.0
+                "PasteAppendRows": {
+                    "Type": 2.0,
+                    "Boolean": 0.0
                 },
-                "Label": {
-                    "Type": 5.0,
-                    "String": "IAM Coefficients"
+                "PasteAppendCols": {
+                    "Type": 2.0,
+                    "Boolean": 0.0
                 },
-                "Description": {
+                "ShowButtons": {
+                    "Type": 2.0,
+                    "Boolean": 1.0
+                },
+                "ShowRows": {
+                    "Type": 2.0,
+                    "Boolean": 1.0
+                },
+                "ShowRowLabels": {
+                    "Type": 2.0,
+                    "Boolean": 0.0
+                },
+                "RowLabels": {
                     "Type": 5.0,
                     "String": ""
                 },
-                "TabOrder": {
+                "ShadeR0C0": {
+                    "Type": 2.0,
+                    "Boolean": 0.0
+                },
+                "VerticalLabel": {
+                    "Type": 5.0,
+                    "String": ""
+                },
+                "HorizontalLabel": {
+                    "Type": 5.0,
+                    "String": ""
+                },
+                "ShadeC0": {
+                    "Type": 2.0,
+                    "Boolean": 0.0
+                },
+                "ShowCols": {
+                    "Type": 2.0,
+                    "Boolean": 0.0
+                },
+                "ShowColLabels": {
+                    "Type": 2.0,
+                    "Boolean": 1.0
+                },
+                "ColLabels": {
+                    "Type": 5.0,
+                    "String": "IAM Coefficients"
+                },
+                "NumRowsLabel": {
+                    "Type": 5.0,
+                    "String": "Rows:"
+                },
+                "NumColsLabel": {
+                    "Type": 5.0,
+                    "String": "Cols:"
+                },
+                "Layout": {
+                    "Type": 3.0,
+                    "Integer": 1.0
+                },
+                "Choices": {
+                    "Type": 5.0,
+                    "String": "Choice1,Choice2"
+                },
+                "HideColumn": {
+                    "Type": 3.0,
+                    "Integer": -1.0
+                },
+                "ShowColumn": {
                     "Type": 3.0,
                     "Integer": -1.0
                 }
@@ -1683,7 +1743,7 @@
                 },
                 "Height": {
                     "Type": 3.0,
-                    "Integer": 372.0
+                    "Integer": 378.0
                 },
                 "Tool Tip": {
                     "Type": 5.0,
@@ -1721,7 +1781,7 @@
             "Units": " ",
             "Group": "Physical Trough Collector Type 3",
             "IndexLabels": "",
-            "Flags": 2.0,
+            "Flags": 3.0,
             "DefaultValue": [
                 1.0,
                 0.0506,
@@ -2085,8 +2145,8 @@
         "};",
         "\r",
         "on_change{\"DISP_opt_model_4\"}=define(){\r",
-        "\tenable(\"OpticalTable_4\", ${DISP_opt_model_4} != 2);\r",
-        "\tenable(\"IAMs_4\", ${DISP_opt_model_4} == 2);\r",
+        "\tshow(\"OpticalTable_4\", ${DISP_opt_model_4} != 2);\r",
+        "\tshow(\"IAMs_4\", ${DISP_opt_model_4} == 2);\r",
         "};"
     ]
 }

--- a/doc/source/csp-physical-trough-model/troughphysical_collectors_scas.rst
+++ b/doc/source/csp-physical-trough-model/troughphysical_collectors_scas.rst
@@ -132,7 +132,7 @@ The optical efficiency is defined as follows:
 **Incidence Angle Modifier Coefficients**
   Coefficients for a polynomial equation defining the incidence angle modifier equation. 
 
-  Click **Edit data** and to specify coefficients for the equation. The default coefficients are for an equation with three terms, but you can use the table to specify more coefficients.
+  Use the incidence angle modifier coefficients table to specify coefficients for the equation. The default coefficients are for an equation with three terms, but you can use the table to specify more coefficients.
 
   The equation captures the degradation of collector performance as the incidence angle (theta) of the solar radiation increases.
 

--- a/doc/source/iph-parabolic-trough/iph_trough_collectors.rst
+++ b/doc/source/iph-parabolic-trough/iph_trough_collectors.rst
@@ -132,7 +132,7 @@ The optical efficiency is defined as follows:
 **Incidence Angle Modifier Coefficients**
   Coefficients for a polynomial equation defining the incidence angle modifier equation. 
 
-  Click **Edit data** and to specify coefficients for the equation. The default coefficients are for an equation with three terms, but you can use the table to specify more coefficients.
+  Use the incidence angle modifier coefficients table to specify coefficients for the equation. The default coefficients are for an equation with three terms, but you can use the table to specify more coefficients.
 
   The equation captures the degradation of collector performance as the incidence angle (theta) of the solar radiation increases.
 


### PR DESCRIPTION
### Description

Modified the physical trough collectors UI page so only the relevant solar position, field incidence, or incidence angle modifier tables are visible, depending on what is selected. This removes the incidence angle modifier coefficient dialog box, and places the table in the UI.

New version:
<img width="876" height="415" alt="image" src="https://github.com/user-attachments/assets/d176b040-a514-4555-9694-fa5bef80b71c" />
<img width="875" height="417" alt="image" src="https://github.com/user-attachments/assets/4d8e364b-944a-4a82-b9f4-6cc07dab76de" />

Previous version:
<img width="842" height="396" alt="image" src="https://github.com/user-attachments/assets/8faf7a3e-c251-48b6-baa7-b4eb59c84ce0" />
<img width="841" height="397" alt="image" src="https://github.com/user-attachments/assets/1719c533-9dce-403f-a367-200e6d3ff6cd" />
<img width="648" height="780" alt="image" src="https://github.com/user-attachments/assets/f7cae15c-d07b-4d6d-b4af-93ab54fdcc1a" />

### Corresponding branches and PRs:

All other branches: develop

### Unit Test Impact:

Expect no changes to any tests. No change to defaults.

### Checklist
- [x] requires help revision and I added that label (I modified the help documentation)
- [x] I've tagged this PR to a milestone