### PR TITLE
Add pre build command to Windows to remove potentially stale json files #2208

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -210,7 +210,7 @@ jobs:
 
 
   build-windows:
-    runs-on: windows-latest
+    runs-on: windows-2022
     strategy:
         matrix:
             python-version: [ '3.10' ]

--- a/api/api_autogen/CMakeLists.txt
+++ b/api/api_autogen/CMakeLists.txt
@@ -239,7 +239,7 @@ if (MSVC)
             TARGET export_config
             PRE_BUILD
             COMMAND ${CMAKE_COMMAND}
-            ARGS -E rm -rf ${CMAKE_CURRENT_SOURCE_DIR}/library/defaults
+            ARGS -E rm -rf ${CMAKE_CURRENT_SOURCE_DIR}/library/defaults/*.*
         )
 
     	add_custom_command(

--- a/api/api_autogen/CMakeLists.txt
+++ b/api/api_autogen/CMakeLists.txt
@@ -234,6 +234,12 @@ if (MSVC)
     )
     endforeach( file_i )
 
+    add_custom_command(
+        TARGET export_config
+        PRE_BUILD
+        COMMAND ${CMAKE_COMMAND}
+        ARGS -E rm -rf ${CMAKE_CURRENT_SOURCE_DIR}/library/defaults
+    )
 
 	add_custom_command(
 		TARGET export_config

--- a/api/api_autogen/CMakeLists.txt
+++ b/api/api_autogen/CMakeLists.txt
@@ -234,18 +234,21 @@ if (MSVC)
     )
     endforeach( file_i )
 
-    add_custom_command(
-        TARGET export_config
-        PRE_BUILD
-        COMMAND ${CMAKE_COMMAND}
-        ARGS -E rm -rf ${CMAKE_CURRENT_SOURCE_DIR}/library/defaults
-    )
+    if(NOT CMAKE_BUILD_TYPE STREQUAL "Debug")
+        add_custom_command(
+            TARGET export_config
+            PRE_BUILD
+            COMMAND ${CMAKE_COMMAND}
+            ARGS -E rm -rf ${CMAKE_CURRENT_SOURCE_DIR}/library/defaults
+        )
 
-	add_custom_command(
-		TARGET export_config
-		POST_BUILD
-		COMMAND cmd /C $<$<CONFIG:Release>:${EXPORT_RUN}>
-	)
+    	add_custom_command(
+    		TARGET export_config
+    		POST_BUILD
+    		COMMAND cmd /C $<$<CONFIG:Release>:${EXPORT_RUN}>
+    	)
+    endif()
+    
 else()
 	if(NOT CMAKE_BUILD_TYPE STREQUAL "Debug")
 		add_custom_command(


### PR DESCRIPTION
Removes the api/api_autogen/library/defaults folder before regenerating json files when the Release build of export_config is run