### PR TITLE
Revert wxConfig to NREL for backward compatibility

### DIFF
--- a/src/main_add.h
+++ b/src/main_add.h
@@ -375,7 +375,7 @@ extern void RegisterReportObjectTypes();
 		return false;
 	}
 
-	g_config = new wxConfig("SystemAdvisorModel", "NLR");
+	g_config = new wxConfig("SystemAdvisorModel", "NREL");
 
 	wxInitAllImageHandlers();
 
@@ -425,7 +425,7 @@ extern void RegisterReportObjectTypes();
 		Settings().Write(fl_key, false);
 
 		// enable web update app
-		wxConfig cfg("SamUpdate3", "NLR");
+		wxConfig cfg("SamUpdate3", "NREL");
 		cfg.Write("allow_web_updates", true);
 
 		// after installing a new version, always show the reminders again until the user turns them off


### PR DESCRIPTION
Fixes https://github.com/NatLabRockies/SAM/issues/2216

See issue for description. Best to test with build SAM-private to test registry settings.

This allows new versions of SAM and DView to access Windows registry and macOS/Linux configuration file settings from old versions of SAM.

### Corresponding branches and PRs:

https://github.com/NatLabRockies/SAM-private/pull/161

### Unit Test Impact:

No impact on tests.

### Checklist
- [ ] requires help revision and I added that label
- [ ] adds, removes, modifies, or deletes variables in existing compute modules
- [ ] adds a new compute module
- [ ] changes defaults
- [X] I've tagged this PR to a milestone

