### PR TITLE
Add additional libssc.so call to get alma linux build working

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -272,7 +272,7 @@ else()
 			    NAMES lk.a lk.lib
 			    PATHS $ENV{LK_LIB} $ENV{LKDIR}/build $ENV{LKDIR}/build/Release)
 	    find_library( SSC_LIB
-			    NAMES ssc.dylib ssc.lib ssc.so
+			    NAMES ssc.dylib ssc.lib ssc.so libssc.so
 			    PATHS $ENV{SSC_LIB} $ENV{SSCDIR}/build/ssc $ENV{SSCDIR}/build/ssc/Release)
 	    target_link_libraries(${SAM_EXE} optimized ${WEX_LIB} optimized ${SSC_LIB} optimized ${LK_LIB})
     endif()


### PR DESCRIPTION
Add libssc.so to release build path for alma linux build.